### PR TITLE
doc: use jsdoc to generate automatic documentation for code editors

### DIFF
--- a/packages/jsx/src/components.tsx
+++ b/packages/jsx/src/components.tsx
@@ -24,32 +24,96 @@ import {
 	txt,
 } from "@tiendanube/nube-sdk-ui";
 
+/**
+ * Creates a `Box` component.
+ *
+ * The `Box` component is a flexible container used for structuring layouts.
+ * It supports properties like width, height, padding, margin, and flex-based alignment.
+ *
+ * @param props - The properties for configuring the box component.
+ * @returns A `NubeComponentBox` object representing the box component.
+ */
 export function Box(props: NubeComponentBoxProps): NubeComponentBox {
 	return box(props);
 }
 
+/**
+ * Creates a `Col` (column) component.
+ *
+ * The `Col` component is a flexible column container used for structuring layouts.
+ * It inherits most properties from `Box`, except for the `direction` property.
+ *
+ * @param props - The properties for configuring the column component.
+ * @returns A `NubeComponentCol` object representing the column component.
+ */
 export function Col(props: NubeComponentColProps): NubeComponentCol {
 	return col(props);
 }
 
+/**
+ * Creates a `Row` component.
+ *
+ * The `Row` component is a flexible row container used for structuring layouts in a horizontal direction.
+ * It inherits most properties from `Box`, except for the `direction` property.
+ *
+ * @param props - The properties for configuring the row component.
+ * @returns A `NubeComponentRow` object representing the row component.
+ */
 export function Row(props: NubeComponentRowProps): NubeComponentRow {
 	return row(props);
 }
 
+/**
+ * Creates a `Field` component.
+ *
+ * The `Field` component represents an input element in a form, such as text fields, dropdowns, or checkboxes.
+ * It supports properties like `name`, `label`, and event handlers (`onChange`, `onBlur`, `onFocus`).
+ *
+ * @param props - The properties for configuring the field component.
+ * @returns A `NubeComponentField` object representing the form field.
+ */
 export function Field(props: NubeComponentFieldProps): NubeComponentField {
 	return field(props);
 }
 
+/**
+ * Creates a `Fragment` component.
+ *
+ * The `Fragment` component is a logical grouping element that allows multiple children
+ * to be wrapped without introducing an additional DOM node.
+ *
+ * @param props - The properties for configuring the fragment component.
+ * @returns A `NubeComponentFragment` object representing the fragment.
+ */
 export function Fragment(
 	props: NubeComponentFragmentProps,
 ): NubeComponentFragment {
 	return fragment(props);
 }
 
+/**
+ * Creates a `Txt` (text) component.
+ *
+ * The `Txt` component is used to render text with optional styling.
+ * It supports properties such as `color`, `background`, `heading` levels (h1-h6),
+ * text formatting `modifiers` (bold, italic, etc.), and inline display.
+ *
+ * @param props - The properties for configuring the text component.
+ * @returns A `NubeComponentTxt` object representing the text component.
+ */
 export function Txt(props: NubeComponentTxtProps): NubeComponentTxt {
 	return txt(props);
 }
 
+/**
+ * Creates an `Img` (image) component.
+ *
+ * The `Img` component is used to display images. It supports properties such as
+ * `src`, `alt`, `width`, `height`, and responsive `sources` for different screen sizes.
+ *
+ * @param props - The properties for configuring the image component.
+ * @returns A `NubeComponentImg` object representing the image component.
+ */
 export function Img(props: NubeComponentImgProps): NubeComponentImg {
 	return img(props);
 }

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -1,20 +1,48 @@
 import type { NubeSDKState } from "./main";
 import type { Prettify } from "./utility";
 
-// ----------------------------
-// ---- Box Component ---------
-// ----------------------------
+/* -------------------------------------------------------------------------- */
+/*                               Utility Types                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Defines units for size measurements.
+ */
 export type SizeUnit = "em" | "rem" | "px" | "%";
+
+/**
+ * Represents a flexible size definition.
+ * It can be a number, a string with a unit, or "auto".
+ */
 export type Size = `${number}${SizeUnit}` | number | "auto";
+
+/**
+ * Ensures URLs are secure by enforcing "https://".
+ */
 export type SecurityURL = `https://${string}`;
+
+/**
+ * Defines possible alignment values for flex container content.
+ */
 export type FlexContent =
 	| "start"
 	| "center"
 	| "space-between"
 	| "space-around"
 	| "space-evenly";
+
+/**
+ * Defines possible alignment values for flex items.
+ */
 export type FlexItems = "start" | "center" | "end" | "stretch";
 
+/* -------------------------------------------------------------------------- */
+/*                            Box Component                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Represents the properties available for a `box` component.
+ */
 export type NubeComponentBoxProps = Prettify<
 	NubeComponentProps &
 		ChildrenProps &
@@ -35,6 +63,9 @@ export type NubeComponentBoxProps = Prettify<
 		}>
 >;
 
+/**
+ * Represents a `box` component, used as a layout container.
+ */
 export type NubeComponentBox = Prettify<
 	NubeComponentBase &
 		NubeComponentBoxProps & {
@@ -42,11 +73,19 @@ export type NubeComponentBox = Prettify<
 		}
 >;
 
-// ----------------------------
-// ---- Col Component ---------
-// ----------------------------
+/* -------------------------------------------------------------------------- */
+/*                            Col Component                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Represents the properties available for a `col` component.
+ * Inherits properties from `box`, excluding `direction`.
+ */
 export type NubeComponentColProps = Omit<NubeComponentBoxProps, "direction">;
 
+/**
+ * Represents a `col` component, used for column-based layouts.
+ */
 export type NubeComponentCol = Prettify<
 	NubeComponentBase &
 		NubeComponentColProps & {
@@ -54,11 +93,19 @@ export type NubeComponentCol = Prettify<
 		}
 >;
 
-// ----------------------------
-// ---- Row Component ---------
-// ----------------------------
+/* -------------------------------------------------------------------------- */
+/*                            Row Component                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Represents the properties available for a `row` component.
+ * Inherits properties from `box`, excluding `direction`.
+ */
 export type NubeComponentRowProps = Omit<NubeComponentBoxProps, "direction">;
 
+/**
+ * Represents a `row` component, used for row-based layouts.
+ */
 export type NubeComponentRow = Prettify<
 	NubeComponentBase &
 		NubeComponentRowProps & {
@@ -66,15 +113,22 @@ export type NubeComponentRow = Prettify<
 		}
 >;
 
-// ----------------------------
-// ---- Field Component -------
-// ----------------------------
+/* -------------------------------------------------------------------------- */
+/*                           Field Component                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Defines a handler for field-related events.
+ */
 export type NubeComponentFieldEventHandler = (data: {
 	type: "change" | "blur" | "focus";
 	state: NubeSDKState;
 	value?: UIValue;
 }) => void;
 
+/**
+ * Represents the properties available for a `field` component.
+ */
 export type NubeComponentFieldProps = Prettify<
 	NubeComponentBase & {
 		name: string;
@@ -85,6 +139,9 @@ export type NubeComponentFieldProps = Prettify<
 	}
 >;
 
+/**
+ * Represents a `field` component, used for form inputs.
+ */
 export type NubeComponentField = Prettify<
 	NubeComponentBase &
 		NubeComponentFieldProps & {
@@ -92,14 +149,21 @@ export type NubeComponentField = Prettify<
 		}
 >;
 
-// ----------------------------
-// ---- Image Component -------
-// ----------------------------
+/* -------------------------------------------------------------------------- */
+/*                           Image Component                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Represents an image source with optional media conditions.
+ */
 export type ImageSource = {
 	src: string;
 	media?: string;
 };
 
+/**
+ * Represents the properties available for an `img` component.
+ */
 export type NubeComponentImgProps = Prettify<
 	NubeComponentBase & {
 		src: string;
@@ -110,6 +174,9 @@ export type NubeComponentImgProps = Prettify<
 	}
 >;
 
+/**
+ * Represents an `img` component, used to display images.
+ */
 export type NubeComponentImg = Prettify<
 	NubeComponentBase &
 		NubeComponentImgProps & {
@@ -117,9 +184,13 @@ export type NubeComponentImg = Prettify<
 		}
 >;
 
-// ----------------------------
-// ---- Txt Component -------
-// ----------------------------
+/* -------------------------------------------------------------------------- */
+/*                           Txt Component                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Defines possible text formatting modifiers.
+ */
 export type TxtModifier =
 	| "bold"
 	| "italic"
@@ -129,6 +200,9 @@ export type TxtModifier =
 	| "uppercase"
 	| "capitalize";
 
+/**
+ * Represents the properties available for a `txt` component.
+ */
 export type NubeComponentTxtProps = Prettify<
 	NubeComponentBase & {
 		color?: string;
@@ -140,6 +214,9 @@ export type NubeComponentTxtProps = Prettify<
 	}
 >;
 
+/**
+ * Represents a `txt` component, used for displaying text with formatting options.
+ */
 export type NubeComponentTxt = Prettify<
 	NubeComponentBase &
 		NubeComponentTxtProps & {
@@ -147,37 +224,59 @@ export type NubeComponentTxt = Prettify<
 		}
 >;
 
-// ----------------------------
-// --- Fragment Component -----
-// ----------------------------
+/* -------------------------------------------------------------------------- */
+/*                          Fragment Component                                */
+/* -------------------------------------------------------------------------- */
 
+/**
+ * Represents the properties available for a `fragment` component.
+ */
 export type NubeComponentFragmentProps = Prettify<
 	NubeComponentBase & ChildrenProps
 >;
 
+/**
+ * Represents a `fragment` component, used as a logical grouping element.
+ */
 export type NubeComponentFragment = Prettify<
 	NubeComponentFragmentProps & {
 		type: "fragment";
 	}
 >;
 
-// ----------------------------
-// ---- Basic Definitions -----
-// ----------------------------
+/* -------------------------------------------------------------------------- */
+/*                         Basic Definitions                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Represents a unique identifier for a UI component.
+ */
 export type NubeComponentId = string;
 
+/**
+ * Defines basic properties for all UI components.
+ */
 export type NubeComponentProps = {
 	id?: NubeComponentId;
 	// DON'T USE THIS, USED INTERNALLY BY THE SDK, ANY VALUE PASSED HERE WILL BE OVERWRITTEN
 	__internalId?: NubeComponentId;
 };
 
+/**
+ * Defines the base structure for all UI components.
+ */
 export type NubeComponentBase = NubeComponentProps;
 
+/**
+ * Defines components that can have child elements.
+ */
 export type ChildrenProps = {
 	children?: NubeComponent | NubeComponent[];
 };
 
+/**
+ * Represents any valid Nube component type.
+ */
 export type NubeComponent =
 	| string
 	| NubeComponentBox
@@ -188,25 +287,52 @@ export type NubeComponent =
 	| NubeComponentImg
 	| NubeComponentTxt;
 
+/**
+ * Represents components that can contain other components as children.
+ */
 export type NubeComponentWithChildren =
 	| NubeComponentBox
 	| NubeComponentCol
 	| NubeComponentRow;
 
+/**
+ * Represents a UI slot where components can be dynamically injected.
+ */
 export type UISlot =
-	| "before_main_content"
-	| "after_main_content"
-	| "before_line_items"
-	| "after_line_items"
-	| "after_contact_form"
-	| "after_address_form"
-	| "after_billing_form";
+	| "before_main_content" // Before the main checkout content.
+	| "after_main_content" // After the main checkout content.
+	| "before_line_items" // Before the list of items in the cart.
+	| "after_line_items" // After the list of items in the cart.
+	| "after_contact_form" // After the contact form in checkout.
+	| "after_address_form" // After the address form in checkout.
+	| "after_billing_form"; // After the billing form in checkout.
 
+/**
+ * Represents the value of a UI component, typically used for form inputs.
+ */
 export type UIValue = string;
+
+/**
+ * Represents a mapping of UI slots to their respective components.
+ */
 export type UISlots = Partial<Record<UISlot, NubeComponent>>;
+
+/**
+ * Represents a mapping of UI component IDs to their respective values.
+ */
 export type UIValues = Record<NubeComponentId, UIValue>;
 
+/**
+ * Represents the UI state, including dynamically injected components and their values.
+ */
 export type UI = {
+	/**
+	 * Contains dynamically injected components into specific UI slots.
+	 */
 	slots: UISlots;
+
+	/**
+	 * Stores values associated with specific UI components, typically form inputs.
+	 */
 	values: UIValues;
 };

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1,75 +1,196 @@
 import type { Nullable } from "./utility";
 
+/**
+ * Represents a product in the cart.
+ * This type maintains compatibility with the API response format.
+ */
 export type Product = {
-	// keep compatibility with api response
+	/** Unique identifier for the product instance in the cart. */
 	id: number;
+
+	/** Name of the product. */
 	name: string;
+
+	/** Price of the product in string format (to match API response). */
 	price: string;
+
+	/** Quantity of this product in the cart. */
 	quantity: number;
+
+	/** Indicates whether the product qualifies for free shipping. */
 	free_shipping: boolean;
+
+	/** Unique identifier for the product (not cart-specific). */
 	product_id: number;
+
+	/** Unique identifier for the selected product variant. */
 	variant_id: number;
+
+	/** URL of the product's thumbnail image. */
 	thumbnail: string;
+
+	/** Variant details, usually a combination of selected attributes. */
 	variant_values: string;
+
+	/** Nullable SKU (Stock Keeping Unit) for the product variant. */
 	sku: Nullable<string>;
+
+	/** Additional properties related to the product (structure unknown). */
 	properties: Array<unknown>;
+
+	/** URL of the product's page. */
 	url: string;
+
+	/** Indicates whether the product is eligible for Ahora 12 financing. */
 	is_ahora_12_eligible: boolean;
 };
 
+/**
+ * Represents the price breakdown for a cart.
+ */
 export type Prices = {
+	/** Discount applied through a coupon. */
 	discount_coupon: number;
+
+	/** Discount applied through a payment gateway. */
 	discount_gateway: number;
+
+	/** Discount applied through a store promotion. */
 	discount_promotion: number;
+
+	/** Cost of shipping. */
 	shipping: number;
+
+	/** Subtotal before discounts and shipping. */
 	subtotal: number;
+
+	/** Final total price after all discounts and shipping. */
 	total: number;
 };
 
+/**
+ * Represents a discount coupon applied to the cart.
+ */
 export type Coupon = {
+	/** The coupon code used. */
 	code: string;
+
+	/** The type of discount (percentage, fixed, etc.). */
 	type: string;
+
+	/** The discount value (format depends on `type`). */
 	value: string;
 };
 
+/**
+ * Represents a successful cart validation.
+ */
 export type CartValidationSuccess = { status: "success" };
+
+/**
+ * Represents a pending cart validation (e.g., async validation in progress).
+ */
 export type CartValidationPending = { status: "pending" };
+
+/**
+ * Represents a failed cart validation, including the reason for failure.
+ */
 export type CartValidationFail = { status: "fail"; reason: string };
 
+/**
+ * Represents the validation status of a cart.
+ * This can indicate success, failure (with a reason), or a pending state.
+ */
 export type CartValidation =
 	| CartValidationSuccess
 	| CartValidationPending
 	| CartValidationFail;
 
+/**
+ * Represents the current state of a shopping cart.
+ */
 export type Cart = {
+	/** Unique identifier for the cart session. */
 	id: string;
+
+	/** Validation status of the cart. */
 	validation: CartValidation;
+
+	/** List of products currently in the cart. */
 	items: Product[];
+
+	/** Breakdown of the cart's pricing details. */
 	prices: Prices;
+
+	/** Optional coupon applied to the cart. */
 	coupon: Nullable<Coupon>;
 };
 
+/**
+ * Represents information about the current store.
+ */
 export type Store = {
+	/** Unique identifier for the store. */
 	id: number;
+
+	/** Name of the store. */
 	name: string;
+
+	/** Domain name associated with the store. */
 	domain: string;
+
+	/** Currency code used in the store (e.g., "USD", "EUR"). */
 	currency: string;
+
+	/** Language code of the store (e.g., "en", "es"). */
 	language: string;
 };
 
+/**
+ * Represents a product category.
+ */
 export type Category = { id: string; name: string };
+
+/**
+ * Represents the different steps in the checkout process.
+ */
 export type Checkout = { step: "start" | "payment" | "success" };
 
+/**
+ * Represents a product page.
+ */
 export type ProductPage = { type: "product"; data: Product };
+
+/**
+ * Represents a category page.
+ */
 export type CategoryPage = { type: "category"; data: Category };
+
+/**
+ * Represents a checkout page.
+ */
 export type CheckoutPage = { type: "checkout"; data: Checkout };
+
+/**
+ * Represents a page within the application.
+ */
 export type Page = CheckoutPage | ProductPage | CategoryPage;
 
+/**
+ * Represents the user's current location within the application.
+ */
 export type AppLocation = {
+	/** The current URL of the application. */
 	url: string;
+
+	/** The current page type and its associated data. */
 	page: Page;
 };
 
+/**
+ * Represents application-wide configuration settings.
+ */
 export type AppConfig = {
+	/** Determines whether cart validation is enabled. */
 	has_cart_validation: boolean;
 };

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -2,42 +2,123 @@ import type { UI } from "./components";
 import type { AppConfig, AppLocation, Cart, Store } from "./domain";
 import type { DeepPartial } from "./utility";
 
+/**
+ * Represents the current state of the NubeSDK.
+ * This state is immutable and contains all relevant application data.
+ */
 export type NubeSDKState = {
-	cart: Cart; // Holds the current cart state and related details
-	config: AppConfig; // Represents App config
-	location: AppLocation; // Represents the user's current location in the app
-	store: Store; // Contains information about the current store
-	ui: UI; // Contains UI configuration
+	/**
+	 * The current cart state, containing products, pricing, and validation status.
+	 */
+	cart: Cart;
+
+	/**
+	 * Application-wide configuration settings, including cart validation rules.
+	 */
+	config: AppConfig;
+
+	/**
+	 * The user's current location within the application, including the page type and URL.
+	 */
+	location: AppLocation;
+
+	/**
+	 * Information about the current store, such as its domain, currency, and language.
+	 */
+	store: Store;
+
+	/**
+	 * Represents UI-related state, including dynamically injected components and their values.
+	 */
+	ui: UI;
 };
 
+/**
+ * Represents the possible events that can be sent within NubeSDK.
+ * These events trigger specific actions within the SDK.
+ */
 export type NubeSDKSendableEvent =
-	| "cart:validate"
-	| "config:set"
-	| "ui:slot:set"
-	| `custom:${string}:${string}`;
+	| "cart:validate" // Triggered to validate the current cart state.
+	| "config:set" // Used to update the SDK configuration.
+	| "ui:slot:set" // Updates a UI slot with new content.
+	| `custom:${string}:${string}`; // Custom events with a specific namespace and identifier.
 
+/**
+ * Represents the possible events that can be listened to within NubeSDK.
+ * These events notify the application about changes in state or actions.
+ */
 export type NubeSDKListenableEvent =
-	| "*"
-	| "cart:update"
-	| "checkout:ready"
-	| "checkout:success"
-	| NubeSDKSendableEvent;
+	| "*" // Wildcard listener for all events.
+	| "cart:update" // Fired when the cart state is updated.
+	| "checkout:ready" // Triggered when checkout is fully initialized.
+	| "checkout:success" // Fired upon successful checkout completion.
+	| NubeSDKSendableEvent; // Includes all sendable events.
 
+/**
+ * Represents a listener function that responds to SDK events.
+ *
+ * @param state - The current immutable state of the SDK.
+ * @param event - The event that was triggered.
+ */
 export type NubeSDKListener = (
 	state: Readonly<NubeSDKState>,
 	event: NubeSDKSendableEvent,
 ) => void;
+
+/**
+ * Represents a function that modifies the SDK state.
+ * It receives the current state and returns a partial update.
+ *
+ * @param state - The current immutable state of the SDK.
+ * @returns A partial update of the SDK state.
+ */
 export type NubeSDKStateModifier = (
 	state: Readonly<NubeSDKState>,
 ) => DeepPartial<NubeSDKState>;
 
+/**
+ * Represents the main interface for interacting with NubeSDK.
+ * Provides methods to listen to events, send events, and retrieve state.
+ */
 export type NubeSDK = {
+	/**
+	 * Registers an event listener.
+	 *
+	 * @param event - The event type to listen for.
+	 * @param listener - The function to execute when the event occurs.
+	 */
 	on(event: NubeSDKListenableEvent, listener: NubeSDKListener): void;
+
+	/**
+	 * Removes a registered event listener.
+	 *
+	 * @param event - The event type to stop listening for.
+	 * @param listener - The function that was previously registered.
+	 */
 	off(event: NubeSDKListenableEvent, listener: NubeSDKListener): void;
+
+	/**
+	 * Sends an event to the SDK, optionally modifying the state.
+	 *
+	 * @param event - The event type to send.
+	 * @param modifier - An optional function to modify the SDK state.
+	 */
 	send(event: NubeSDKSendableEvent, modifier?: NubeSDKStateModifier): void;
+
+	/**
+	 * Retrieves the current immutable state of the SDK.
+	 *
+	 * @returns The current state of NubeSDK.
+	 */
 	getState(): Readonly<NubeSDKState>;
 };
 
+/**
+ * Represents a Nube application, which is a function that receives
+ * an instance of `NubeSDK` to interact with.
+ *
+ * @param nube - The NubeSDK instance provided to the application.
+ */
 export type NubeApp = (nube: NubeSDK) => void;
 
 declare global {

--- a/packages/types/src/utility.ts
+++ b/packages/types/src/utility.ts
@@ -1,15 +1,34 @@
+/**
+ * Creates a new type with the same keys and values as `T`, but removes any
+ * extra inferred complexity. Useful for improving type readability.
+ */
 export type Prettify<T> = {
 	[K in keyof T]: T[K];
 } & {};
 
+/**
+ * Represents a type that can either be `T` or `null`.
+ *
+ * @template T The base type.
+ */
 export type Nullable<T> = T | null;
 
+/**
+ * Recursively makes all properties of `T` nullable.
+ *
+ * @template T The base type.
+ */
 export type DeepNullable<T> = {
 	[K in keyof T]: T[K] extends object
 		? Nullable<DeepNullable<T[K]>>
 		: Nullable<T[K]>;
 };
 
+/**
+ * Recursively makes all properties of `T` optional.
+ *
+ * @template T The base type.
+ */
 export type DeepPartial<T> = {
 	[K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };

--- a/packages/ui/src/components/box.ts
+++ b/packages/ui/src/components/box.ts
@@ -3,6 +3,15 @@ import type {
 	NubeComponentBoxProps,
 } from "@tiendanube/nube-sdk-types";
 
+/**
+ * Creates a `box` component.
+ *
+ * A `box` is a flexible container that can be used for layout purposes.
+ * It supports properties like width, height, padding, margin, and flex-based alignment.
+ *
+ * @param props - The properties for configuring the box component.
+ * @returns A `NubeComponentBox` object representing the box component.
+ */
 export const box = (props: NubeComponentBoxProps): NubeComponentBox => ({
 	type: "box",
 	...props,

--- a/packages/ui/src/components/col.ts
+++ b/packages/ui/src/components/col.ts
@@ -3,6 +3,15 @@ import type {
 	NubeComponentColProps,
 } from "@tiendanube/nube-sdk-types";
 
+/**
+ * Creates a `col` (column) component.
+ *
+ * A `col` is a flexible column container that can be used for structuring layouts.
+ * It inherits most properties from `box`, except for the `direction` property.
+ *
+ * @param props - The properties for configuring the column component.
+ * @returns A `NubeComponentCol` object representing the column component.
+ */
 export const col = (props: NubeComponentColProps): NubeComponentCol => ({
 	type: "col",
 	...props,

--- a/packages/ui/src/components/field.ts
+++ b/packages/ui/src/components/field.ts
@@ -3,6 +3,15 @@ import type {
 	NubeComponentFieldProps,
 } from "@tiendanube/nube-sdk-types";
 
+/**
+ * Creates a `field` component.
+ *
+ * A `field` represents an input element in a form, such as text fields, dropdowns, or checkboxes.
+ * It supports properties like `name`, `label`, and event handlers (`onChange`, `onBlur`, `onFocus`).
+ *
+ * @param props - The properties for configuring the field component.
+ * @returns A `NubeComponentField` object representing the form field.
+ */
 export const field = (props: NubeComponentFieldProps): NubeComponentField => ({
 	type: "field",
 	...props,

--- a/packages/ui/src/components/fragment.ts
+++ b/packages/ui/src/components/fragment.ts
@@ -3,6 +3,15 @@ import type {
 	NubeComponentFragmentProps,
 } from "@tiendanube/nube-sdk-types";
 
+/**
+ * Creates a `fragment` component.
+ *
+ * A `fragment` is a logical grouping element that allows multiple children
+ * to be wrapped without introducing an additional DOM node.
+ *
+ * @param props - The properties for configuring the fragment component.
+ * @returns A `NubeComponentFragment` object representing the fragment.
+ */
 export const fragment = (
 	props: NubeComponentFragmentProps,
 ): NubeComponentFragment => ({

--- a/packages/ui/src/components/img.ts
+++ b/packages/ui/src/components/img.ts
@@ -3,6 +3,15 @@ import type {
 	NubeComponentImgProps,
 } from "@tiendanube/nube-sdk-types";
 
+/**
+ * Creates an `img` (image) component.
+ *
+ * The `img` component is used to display images. It supports properties such as
+ * `src`, `alt`, `width`, `height`, and responsive `sources` for different screen sizes.
+ *
+ * @param props - The properties for configuring the image component.
+ * @returns A `NubeComponentImg` object representing the image component.
+ */
 export const img = (props: NubeComponentImgProps): NubeComponentImg => ({
 	type: "img",
 	...props,

--- a/packages/ui/src/components/row.ts
+++ b/packages/ui/src/components/row.ts
@@ -3,6 +3,15 @@ import type {
 	NubeComponentRowProps,
 } from "@tiendanube/nube-sdk-types";
 
+/**
+ * Creates a `row` component.
+ *
+ * A `row` is a flexible container used for structuring layouts in a horizontal direction.
+ * It inherits most properties from `box`, except for the `direction` property.
+ *
+ * @param props - The properties for configuring the row component.
+ * @returns A `NubeComponentRow` object representing the row component.
+ */
 export const row = (props: NubeComponentRowProps): NubeComponentRow => ({
 	type: "row",
 	...props,

--- a/packages/ui/src/components/txt.ts
+++ b/packages/ui/src/components/txt.ts
@@ -3,6 +3,16 @@ import type {
 	NubeComponentTxtProps,
 } from "@tiendanube/nube-sdk-types";
 
+/**
+ * Creates a `txt` (text) component.
+ *
+ * The `txt` component is used to render text with optional styling.
+ * It supports properties such as `color`, `background`, `heading` levels (h1-h6),
+ * text formatting `modifiers` (bold, italic, etc.), and inline display.
+ *
+ * @param props - The properties for configuring the text component.
+ * @returns A `NubeComponentTxt` object representing the text component.
+ */
 export const txt = (props: NubeComponentTxtProps): NubeComponentTxt => ({
 	type: "txt",
 	...props,


### PR DESCRIPTION
# Description

This PR adds a bunch of JSDoc comments  for better "in-code" documentation.

Code editors with LSP support can automatically identify and display them to the partner developer, providing a better development experience.

In the future we may use them to automate part of our documentation process.

## Screenshots

![Screenshot 2025-02-03 at 15 41 31](https://github.com/user-attachments/assets/d472acdf-5fe9-41d7-a60c-51e9650f92c9)

![Screenshot 2025-02-03 at 15 42 43](https://github.com/user-attachments/assets/7a4d83c5-f342-4925-9e51-f0248119b378)


![Screenshot 2025-02-03 at 15 52 30](https://github.com/user-attachments/assets/019e2f38-9d8c-4b0b-8249-86d8c49a6432)

![Screenshot 2025-02-03 at 15 53 11](https://github.com/user-attachments/assets/e2bf7055-064a-4d27-b80a-01faafc71f26)

![Screenshot 2025-02-03 at 15 49 44](https://github.com/user-attachments/assets/a5965706-9885-4942-a892-23288094b0be)

![Screenshot 2025-02-03 at 15 50 10](https://github.com/user-attachments/assets/e2617dad-191f-44d5-b25a-8a4a36fd9e0e)

![Screenshot 2025-02-03 at 15 51 14](https://github.com/user-attachments/assets/ddb8a153-b099-4b95-8fd4-9aa85f6f47cf)

![Screenshot 2025-02-03 at 15 50 46](https://github.com/user-attachments/assets/cd941a20-3001-4e82-85b0-0daaf50a6531)

