### PR TITLE
feat(ui): add dialog component

### DIFF
--- a/packages/jsx/src/components.tsx
+++ b/packages/jsx/src/components.tsx
@@ -5,6 +5,8 @@ import type {
 	NubeComponentCheckProps,
 	NubeComponentCol,
 	NubeComponentColProps,
+	NubeComponentDialog,
+	NubeComponentDialogProps,
 	NubeComponentField,
 	NubeComponentFieldProps,
 	NubeComponentFragment,
@@ -22,6 +24,7 @@ import {
 	box,
 	check,
 	col,
+	dialog,
 	field,
 	fragment,
 	img,
@@ -151,4 +154,17 @@ export function TxtArea(
  */
 export function Img(props: NubeComponentImgProps): NubeComponentImg {
 	return img(props);
+}
+
+/**
+ * Creates a `Dialog` component.
+ *
+ * The `Dialog` component is a modal container used for displaying messages,
+ * interactive content, and specific actions.
+ *
+ * @param props - The properties for configuring the dialog component.
+ * @returns A `NubeComponentDialog` object representing the dialog component.
+ */
+export function Dialog(props: NubeComponentDialogProps): NubeComponentDialog {
+	return dialog(props);
 }

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -74,6 +74,48 @@ export type NubeComponentBox = Prettify<
 >;
 
 /* -------------------------------------------------------------------------- */
+/*                            Dialog Component                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Defines a handler for field-related events.
+ */
+export type NubeComponentDialogEventHandler = NubeComponentEventHandler<
+	"click",
+	string
+>;
+
+/**
+ * Represents the properties available for a `dialog` component.
+ */
+export type NubeComponentDialogProps = Prettify<
+	NubeComponentProps &
+		ChildrenProps &
+		Partial<{
+			open: boolean;
+			onClose: NubeComponentDialogEventHandler;
+			background: string;
+			padding: Size;
+			width: Size;
+			height: Size;
+			borderRadius: Size;
+			top: Size;
+			left: Size;
+			transform: string;
+		}>
+>;
+
+/**
+ * Represents a `dialog` component, used as a layout container.
+ */
+export type NubeComponentDialog = Prettify<
+	NubeComponentBase &
+		NubeComponentDialogProps & {
+			type: "dialog";
+		}
+>;
+
+/* -------------------------------------------------------------------------- */
 /*                            Col Component                                   */
 /* -------------------------------------------------------------------------- */
 
@@ -136,6 +178,7 @@ export type NubeComponentFieldEventHandler = NubeComponentEventHandler<
 	"change" | "focus" | "blur",
 	string
 >;
+
 /**
  * Represents the properties available for a `field` component.
  */
@@ -365,7 +408,8 @@ export type NubeComponent =
 	| NubeComponentImg
 	| NubeComponentTxt
 	| NubeComponentCheck
-	| NubeComponentTxtArea;
+	| NubeComponentTxtArea
+	| NubeComponentDialog;
 
 /**
  * Represents components that can contain other components as children.

--- a/packages/ui/src/components/dialog.ts
+++ b/packages/ui/src/components/dialog.ts
@@ -1,0 +1,20 @@
+import type {
+	NubeComponentDialog,
+	NubeComponentDialogProps,
+} from "@tiendanube/nube-sdk-types";
+
+/**
+ * Creates a `dialog` component.
+ *
+ * A `dialog` is a modal window used for user interactions,
+ * allowing the display of titles, content, and specific actions.
+ *
+ * @param props - The properties for configuring the dialog component.
+ * @returns A `NubeComponentDialog` object representing the dialog component.
+ */
+export const dialog = (
+	props: NubeComponentDialogProps,
+): NubeComponentDialog => ({
+	type: "dialog",
+	...props,
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,3 +7,4 @@ export * from "./components/img";
 export * from "./components/txt";
 export * from "./components/check";
 export * from "./components/txtarea";
+export * from "./components/dialog";


### PR DESCRIPTION
## Description

This PR add the base structure of UI components package and layout components.

Inclues:

- dialog

## Example

```typescript
import type { NubeSDK } from "@tiendanube/nube-sdk-types";
import { Dialog, Txt } from "@tiendanube/nube-sdk-jsx";

export function Component() {
  return (
    <Dialog open>
      <Txt>Hola Mundo</Txt>
    </Dialog>
  );
}

export function App(nube: NubeSDK) {
  nube.send("ui:slot:set", () => ({
    ui: {
      slots: {
        before_main_content: <Component />,
      },
    },
  }));
}
```