### PR TITLE
feat: add object queries to location

### DIFF
--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -185,6 +185,14 @@ export type AppLocation = {
 
 	/** The current page type and its associated data. */
 	page: Page;
+
+	/**
+	 * Query parameters extracted from the URL.
+	 *
+	 * Each key represents the name of a query parameter, and its corresponding
+	 * value represents the value of that query parameter.
+	 */
+	queries: Record<string, string>;
 };
 
 /**


### PR DESCRIPTION
I'm adding a object queries into location.

## Example:

```JSON
{
  "url": "http://localhost:3000/checkout/v3/start/542542822/45ca7695ab05cb6b76fffe8a00256175a2fb7bad?from_store=1&rc=1",
  "page": {
    "type": "checkout",
    "data": {
      "step": "start"
    }
  },
  "queries": {
    "from_store": "1",
    "rc": "1"
  }
}
```