### PR TITLE
feat(ui): add button component

### DIFF
--- a/packages/jsx/src/components.tsx
+++ b/packages/jsx/src/components.tsx
@@ -1,6 +1,8 @@
 import type {
 	NubeComponentBox,
 	NubeComponentBoxProps,
+	NubeComponentButton,
+	NubeComponentButtonProps,
 	NubeComponentCheck,
 	NubeComponentCheckProps,
 	NubeComponentCol,
@@ -22,6 +24,7 @@ import type {
 } from "@tiendanube/nube-sdk-types";
 import {
 	box,
+	button,
 	check,
 	col,
 	dialog,
@@ -83,6 +86,19 @@ export function Row(props: NubeComponentRowProps): NubeComponentRow {
  */
 export function Field(props: NubeComponentFieldProps): NubeComponentField {
 	return field(props);
+}
+
+/**
+ * Creates a `Button` component.
+ *
+ * The `Button` component represents a clickable element typically used to trigger an action or submit a form.
+ * It supports properties like `text` and event handlers (e.g., `onClick`).
+ *
+ * @param props - The properties for configuring the button component.
+ * @returns A `NubeComponentButton` object representing the button component.
+ */
+export function Button(props: NubeComponentButtonProps): NubeComponentButton {
+	return button(props);
 }
 
 /**

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -203,6 +203,40 @@ export type NubeComponentField = Prettify<
 >;
 
 /* -------------------------------------------------------------------------- */
+/*                          Button Component                                */
+/* -------------------------------------------------------------------------- */
+
+export type NubeComponentButtonEventHandler = NubeComponentEventHandler<
+	"click",
+	string
+>;
+
+/**
+ * Represents the properties available for a `button` component.
+ */
+export type NubeComponentButtonProps = Prettify<
+	NubeComponentBase &
+		Partial<{
+			children: string;
+			disabled: boolean;
+			variant: "primary" | "secondary" | "transparent" | "link";
+			width: Size;
+			height: Size;
+			onClick: NubeComponentButtonEventHandler;
+		}>
+>;
+
+/**
+ * Represents a `button` component.
+ */
+export type NubeComponentButton = Prettify<
+	NubeComponentBase &
+		NubeComponentButtonProps & {
+			type: "button";
+		}
+>;
+
+/* -------------------------------------------------------------------------- */
 /*                            Check Component                                 */
 /* -------------------------------------------------------------------------- */
 
@@ -409,7 +443,8 @@ export type NubeComponent =
 	| NubeComponentTxt
 	| NubeComponentCheck
 	| NubeComponentTxtArea
-	| NubeComponentDialog;
+	| NubeComponentDialog
+	| NubeComponentButton;
 
 /**
  * Represents components that can contain other components as children.

--- a/packages/ui/src/components/button.ts
+++ b/packages/ui/src/components/button.ts
@@ -1,0 +1,20 @@
+import type {
+	NubeComponentButton,
+	NubeComponentButtonProps,
+} from "@tiendanube/nube-sdk-types";
+
+/**
+ * Creates a `button` component.
+ *
+ * A `button` represents a clickable element typically used to trigger an action or submit a form.
+ * It supports properties such as `text`, `onClick`, and style configurations.
+ *
+ * @param props - The properties for configuring the button component.
+ * @returns A `NubeComponentButton` object representing the button component.
+ */
+export const button = (
+	props: NubeComponentButtonProps,
+): NubeComponentButton => ({
+	type: "button",
+	...props,
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,3 +8,4 @@ export * from "./components/txt";
 export * from "./components/check";
 export * from "./components/txtarea";
 export * from "./components/dialog";
+export * from "./components/button";


### PR DESCRIPTION
## Description

This PR add the base structure of UI components package and layout components.

Inclues:

- button

## Example

```typescript
import type { NubeSDK } from "@tiendanube/nube-sdk-types";
import { Button } from "@tiendanube/nube-sdk-jsx";

export function Component() {
  return (
    <Button variant="primary">Hello World!</Button>
  );
}

export function App(nube: NubeSDK) {
  nube.getState().store

  nube.send("ui:slot:set", () => ({
    ui: {
      slots: {
        before_main_content: <Component />,
      },
    },
  }));
}
```