### PR TITLE
fix(create-nube-app): cancellation process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2095,7 +2095,7 @@
       }
     },
     "packages/create-nube-app": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.10.0",

--- a/packages/create-nube-app/package.json
+++ b/packages/create-nube-app/package.json
@@ -3,7 +3,7 @@
 	"description": "Create Nube App",
 	"author": "Tiendanube / Nuvemshop",
 	"license": "MIT",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"bin": {
 		"create-nube-app": "dist/index.js"
 	},

--- a/packages/create-nube-app/src/index.ts
+++ b/packages/create-nube-app/src/index.ts
@@ -92,8 +92,10 @@ async function main(): Promise<void> {
 		placeholder: defaultValue,
 		validate: validateProjectName,
 	});
-	const projectName = formatProjectName(promptProjectName as string);
-	if (prompts.isCancel(projectName)) return cancel();
+	const projectName = formatProjectName(
+		typeof promptProjectName === "string" ? promptProjectName : "",
+	);
+	if (prompts.isCancel(promptProjectName)) return cancel();
 
 	const promptTemplateName = await prompts.select({
 		message: "Select a template:",
@@ -104,7 +106,7 @@ async function main(): Promise<void> {
 		],
 	});
 	const templateName = promptTemplateName as string;
-	if (prompts.isCancel(templateName)) return cancel();
+	if (prompts.isCancel(promptTemplateName)) return cancel();
 
 	const dest = path.resolve(process.cwd(), projectName);
 	const src = path.join(__dirname, `../templates/${templateName}`);


### PR DESCRIPTION
## Includes:

- Fix project name validation in the cancellation flow when the user presses `Cntl + C` to skip the process.

## Screenshots

**BEFORE**
<img width="1035" alt="Captura de Tela 2025-04-09 às 11 21 22" src="https://github.com/user-attachments/assets/4f2428ce-3c1d-4e66-8441-b6b41eb61007" />

**AFTER**
<img width="1035" alt="Captura de Tela 2025-04-09 às 11 20 56" src="https://github.com/user-attachments/assets/3271b37f-66eb-46cb-a206-61c84cd5e22a" />