### PR TITLE
refactor(types): change cart coupon type from Nullable to DeepPartial

### DIFF
--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1,4 +1,4 @@
-import type { Nullable, Prettify } from "./utility";
+import type { DeepPartial, Nullable, Prettify } from "./utility";
 
 /**
  * Represents a product in the cart.
@@ -123,7 +123,7 @@ export type Cart = {
 	prices: Prices;
 
 	/** Optional coupon applied to the cart. */
-	coupon: Nullable<Coupon>;
+	coupon: DeepPartial<Coupon>;
 };
 
 /**


### PR DESCRIPTION
# Change cart coupon type from Nullable to DeepPartial

## Description
This PR changes the type of the `coupon` property in the `Cart` object from `Nullable<Coupon>` to `DeepPartial<Coupon>`.

> [!IMPORTANT]  
> This change was necessary to avoid the need to pass the `type` and `discount` properties when send a `coupon:add` event.

```typescript
nube.send("coupon:add", () => ({
  cart: {
    coupon: {
      code: "TESTE",
      type: "", // we don't need this property to add a coupon.
      discount: "", // we don't need this property to add a coupon.
    },
  },
}));
```