### PR TITLE
feat(ui): add component field value

### DIFF
--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -144,6 +144,7 @@ export type NubeComponentFieldProps = Prettify<
 	NubeComponentBase & {
 		name: string;
 		label: string;
+		value?: string;
 		onChange?: NubeComponentFieldEventHandler;
 		onBlur?: NubeComponentFieldEventHandler;
 		onFocus?: NubeComponentFieldEventHandler;
@@ -246,6 +247,7 @@ export type NubeComponentTextareaProps = Prettify<
 		label: string;
 		maxLength?: number;
 		row?: number;
+		value?: string;
 		onChange?: NubeComponentTextareaEventHandler;
 		onBlur?: NubeComponentTextareaEventHandler;
 		onFocus?: NubeComponentTextareaEventHandler;


### PR DESCRIPTION
Add `value` property to `Field` and `TextArea` components to set initial value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a value in input field and textarea components, enabling more flexible control of their content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->