### PR TITLE
feat(types): add before_payment_options UI slot

### DIFF
--- a/packages/doc/docs/state.md
+++ b/packages/doc/docs/state.md
@@ -335,6 +335,7 @@ type UISlot =
   | "after_address_form" // After the address form in checkout
   | "after_billing_form" // After the billing form in checkout
   | "after_payment_options" // After the payment options in checkout
+  | "before_payment_options" // Before the payment options in checkout
   | "before_address_form" // Before the address form in checkout
   | "before_billing_form" // Before the billing form in checkout
   | "before_contact_form" // Before the contact form in checkout

--- a/packages/doc/docs/ui-slots.md
+++ b/packages/doc/docs/ui-slots.md
@@ -18,6 +18,7 @@ These are the slots that are available in checkout:
 | after_address_form    | start                  |
 | after_billing_form    | start                  |
 | after_payment_options | payment                |
+| before_payment_options| payment                |
 | before_address_form   | start                  |
 | before_billing_form   | start                  |
 | before_contact_form   | start                  |

--- a/packages/doc/es/docs/state.md
+++ b/packages/doc/es/docs/state.md
@@ -335,6 +335,7 @@ type UISlot =
   | "after_address_form" // Después del formulario de dirección en el checkout
   | "after_billing_form" // Después del formulario de facturación en el checkout
   | "after_payment_options" // Después de las opciones de pago en el checkout
+  | "before_payment_options"// Antes de las opciones de pago en el checkout
   | "before_address_form" // Antes del formulario de dirección en el checkout
   | "before_billing_form" // Antes del formulario de facturación en el checkout
   | "before_contact_form" // Antes del formulario de contacto en el checkout

--- a/packages/doc/es/docs/ui-slots.md
+++ b/packages/doc/es/docs/ui-slots.md
@@ -18,6 +18,7 @@ Estos son los slots disponibles en el checkout:
 | after_address_form    | start                     |
 | after_billing_form    | start                     |
 | after_payment_options | payment                   |
+| before_payment_options| payment                   |
 | before_address_form   | start                     |
 | before_billing_form   | start                     |
 | before_contact_form   | start                     |

--- a/packages/doc/pt/docs/state.md
+++ b/packages/doc/pt/docs/state.md
@@ -335,6 +335,7 @@ type UISlot =
   | "after_address_form" // Depois do formulário de endereço no checkout
   | "after_billing_form" // Depois do formulário de faturamento no checkout
   | "after_payment_options" // Depois das opções de pagamento no checkout
+  | "before_payment_options" // Antes das opções de pagamento no checkout
   | "before_address_form" // Antes do formulário de endereço no checkout
   | "before_billing_form" // Antes do formulário de faturamento no checkout
   | "before_contact_form" // Antes do formulário de contato no checkout

--- a/packages/doc/pt/docs/ui-slots.md
+++ b/packages/doc/pt/docs/ui-slots.md
@@ -18,6 +18,7 @@ Estes são os slots disponíveis no checkout:
 | after_address_form    | start                       |
 | after_billing_form    | start                       |
 | after_payment_options | payment                     |
+| before_payment_options| payment                     |
 | before_address_form   | start                       |
 | before_billing_form   | start                       |
 | before_contact_form   | start                       |

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -425,6 +425,7 @@ export type UISlot =
 	| "after_address_form" // After the address form in checkout.
 	| "after_billing_form" // After the billing form in checkout.
 	| "after_payment_options" // After the payment options in checkout.
+	| "before_payment_options" // Before the payment options in checkout.
 	| "before_address_form" // Before the address form in checkout.
 	| "before_billing_form" // Before the billing form in checkout.
 	| "before_contact_form" // Before the contact form in checkout.


### PR DESCRIPTION
This pull request introduces a new UI slot, `before_payment_options`, to the checkout process and updates related documentation across multiple languages. The changes ensure consistency between the codebase and the documentation.

### Addition of the `before_payment_options` UI slot:

* [`packages/types/src/components.ts`](diffhunk://#diff-fd33944bcaf3d52cd5caed7db807a07303486ae4fae74bb1265999cec7e7e82eR428): Added the `before_payment_options` slot to the `UISlot` type, enabling customization before the payment options in checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new UI slot, "before_payment_options," allowing components to be placed before the payment options section in the checkout flow.

- **Documentation**
	- Updated documentation in multiple languages to reflect the addition of the "before_payment_options" UI slot in the checkout process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->