### PR TITLE
docs(types): add floating and checkout slots

### DIFF
--- a/packages/create-nube-app/package.json
+++ b/packages/create-nube-app/package.json
@@ -3,7 +3,7 @@
 	"description": "Create Nube App",
 	"author": "Tiendanube / Nuvemshop",
 	"license": "MIT",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"bin": {
 		"create-nube-app": "dist/index.js"
 	},

--- a/packages/create-nube-app/templates/minimal-ui-jsx/package.json
+++ b/packages/create-nube-app/templates/minimal-ui-jsx/package.json
@@ -16,7 +16,7 @@
 		"@biomejs/biome": "^1.9.4",
 		"@tiendanube/nube-sdk-ui": "^0.5.0",
 		"@tiendanube/nube-sdk-jsx": "^0.5.0",
-		"@tiendanube/nube-sdk-types": "^0.11.0",
+		"@tiendanube/nube-sdk-types": "^0.12.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/create-nube-app/templates/minimal-ui/package.json
+++ b/packages/create-nube-app/templates/minimal-ui/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@tiendanube/nube-sdk-ui": "^0.5.0",
-		"@tiendanube/nube-sdk-types": "^0.11.0",
+		"@tiendanube/nube-sdk-types": "^0.12.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/create-nube-app/templates/minimal/package.json
+++ b/packages/create-nube-app/templates/minimal/package.json
@@ -13,7 +13,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-types": "^0.11.0",
+		"@tiendanube/nube-sdk-types": "^0.12.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/doc/docs/state.md
+++ b/packages/doc/docs/state.md
@@ -40,9 +40,8 @@ import type { NubeSDK, NubeSDKState } from '@tiendanube/nube-sdk-types';
 export function App(nube: NubeSDK) {
   // Listen for state changes
   nube.on('customer:update', (state: Readonly<NubeSDKState>) => {
-      const customerEmail = state.customer.email;
-      const customerAddress = state.customer.address;
-    }
+    const customerEmail = state.customer.email;
+    const customerAddress = state.customer.address;
   });
 }
 ```
@@ -329,6 +328,7 @@ type UIValues = Record<NubeComponentId, UIValue>;
 type UISlot =
   | "before_main_content" // Before the main checkout content
   | "after_main_content" // After the main checkout content
+  | "after_line_items_price" // After the line items price in checkout
   | "before_line_items" // Before the list of items in the cart
   | "after_line_items" // After the list of items in the cart
   | "after_contact_form" // After the contact form in checkout
@@ -338,6 +338,12 @@ type UISlot =
   | "before_address_form" // Before the address form in checkout
   | "before_billing_form" // Before the billing form in checkout
   | "before_contact_form" // Before the contact form in checkout
+  | "before_shipping_form" // Before the shipping form in checkout
+  | "after_shipping_form" // After the shipping form in checkout
+  | "corner_top_left" // Top left corner of the checkout
+  | "corner_top_right" // Top right corner of the checkout
+  | "corner_bottom_left" // Bottom left corner of the checkout
+  | "corner_bottom_right" // Bottom right corner of the checkout
   | "modal_content"; // Content of a modal dialog in checkout
 
 /**

--- a/packages/doc/docs/ui-slots.md
+++ b/packages/doc/docs/ui-slots.md
@@ -21,6 +21,12 @@ These are the slots that are available in checkout:
 | before_address_form   | start                  |
 | before_billing_form   | start                  |
 | before_contact_form   | start                  |
+| before_shipping_form  | start                  |
+| after_shipping_form   | start                  |
+| corner_top_left       | start, payment, finish |
+| corner_top_right      | start, payment, finish |
+| corner_bottom_left    | start, payment, finish |
+| corner_bottom_right   | start, payment, finish |
 | modal_content         | start, payment, finish |
 
 ### Desktop Slot location

--- a/packages/doc/es/docs/state.md
+++ b/packages/doc/es/docs/state.md
@@ -40,9 +40,8 @@ import type { NubeSDK, NubeSDKState } from '@tiendanube/nube-sdk-types';
 export function App(nube: NubeSDK) {
   // Escuchar cambios de estado
   nube.on('customer:update', (state: Readonly<NubeSDKState>) => {
-      const customerEmail = state.customer.email;
-      const customerAddress = state.customer.address;
-    }
+    const customerEmail = state.customer.email;
+    const customerAddress = state.customer.address;
   });
 }
 ```
@@ -65,7 +64,7 @@ export function App(nube: NubeSDK) {
     return {
       ui: {
         slots: {
-          before_main_content: <Text>{`Hello ${storeName}!`}</Text>,
+          before_main_content: <Text>{`¡Hola ${storeName}!`}</Text>,
         },
       },
     };
@@ -329,6 +328,7 @@ type UIValues = Record<NubeComponentId, UIValue>;
 type UISlot =
   | "before_main_content" // Antes del contenido principal del checkout
   | "after_main_content" // Después del contenido principal del checkout
+  | "after_line_items_price" // Después del precio de los items en el checkout
   | "before_line_items" // Antes de la lista de items en el carrito
   | "after_line_items" // Después de la lista de items en el carrito
   | "after_contact_form" // Después del formulario de contacto en el checkout
@@ -338,6 +338,12 @@ type UISlot =
   | "before_address_form" // Antes del formulario de dirección en el checkout
   | "before_billing_form" // Antes del formulario de facturación en el checkout
   | "before_contact_form" // Antes del formulario de contacto en el checkout
+  | "before_shipping_form" // Antes del formulario de envío en el checkout
+  | "after_shipping_form" // Después del formulario de envío en el checkout
+  | "corner_top_left" // Esquina superior izquierda del checkout
+  | "corner_top_right" // Esquina superior derecha del checkout
+  | "corner_bottom_left" // Esquina inferior izquierda del checkout
+  | "corner_bottom_right" // Esquina inferior derecha del checkout
   | "modal_content"; // Contenido de un diálogo modal en el checkout
 
 /**

--- a/packages/doc/es/docs/ui-slots.md
+++ b/packages/doc/es/docs/ui-slots.md
@@ -21,6 +21,12 @@ Estos son los slots disponibles en el checkout:
 | before_address_form   | start                     |
 | before_billing_form   | start                     |
 | before_contact_form   | start                     |
+| before_shipping_form  | start                     |
+| after_shipping_form   | start                     |
+| corner_top_left       | start, payment, finish    |
+| corner_top_right      | start, payment, finish    |
+| corner_bottom_left    | start, payment, finish    |
+| corner_bottom_right   | start, payment, finish    |
 | modal_content         | start, payment, finish    |
 
 ### Ubicación de los Slots en Desktop

--- a/packages/doc/pt/docs/state.md
+++ b/packages/doc/pt/docs/state.md
@@ -40,9 +40,8 @@ import type { NubeSDK, NubeSDKState } from '@tiendanube/nube-sdk-types';
 export function App(nube: NubeSDK) {
   // Escutar mudanças de estado
   nube.on('customer:update', (state: Readonly<NubeSDKState>) => {
-      const customerEmail = state.customer.email;
-      const customerAddress = state.customer.address;
-    }
+    const customerEmail = state.customer.email;
+    const customerAddress = state.customer.address;
   });
 }
 ```
@@ -329,6 +328,7 @@ type UIValues = Record<NubeComponentId, UIValue>;
 type UISlot =
   | "before_main_content" // Antes do conteúdo principal do checkout
   | "after_main_content" // Depois do conteúdo principal do checkout
+  | "after_line_items_price" // Depois do preço dos itens no checkout
   | "before_line_items" // Antes da lista de itens no carrinho
   | "after_line_items" // Depois da lista de itens no carrinho
   | "after_contact_form" // Depois do formulário de contato no checkout
@@ -338,6 +338,12 @@ type UISlot =
   | "before_address_form" // Antes do formulário de endereço no checkout
   | "before_billing_form" // Antes do formulário de faturamento no checkout
   | "before_contact_form" // Antes do formulário de contato no checkout
+  | "before_shipping_form" // Antes do formulário de envio no checkout
+  | "after_shipping_form" // Depois do formulário de envio no checkout
+  | "corner_top_left" // Canto superior esquerdo do checkout
+  | "corner_top_right" // Canto superior direito do checkout
+  | "corner_bottom_left" // Canto inferior esquerdo do checkout
+  | "corner_bottom_right" // Canto inferior direito do checkout
   | "modal_content"; // Conteúdo de um diálogo modal no checkout
 
 /**

--- a/packages/doc/pt/docs/ui-slots.md
+++ b/packages/doc/pt/docs/ui-slots.md
@@ -21,6 +21,12 @@ Estes são os slots disponíveis no checkout:
 | before_address_form   | start                       |
 | before_billing_form   | start                       |
 | before_contact_form   | start                       |
+| before_shipping_form  | start                       |
+| after_shipping_form   | start                       |
+| corner_top_left       | start, payment, finish      |
+| corner_top_right      | start, payment, finish      |
+| corner_bottom_left    | start, payment, finish      |
+| corner_bottom_right   | start, payment, finish      |
 | modal_content         | start, payment, finish      |
 
 ### Localização dos Slots no Desktop

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -429,7 +429,13 @@ export type UISlot =
 	| "before_billing_form" // Before the billing form in checkout.
 	| "before_contact_form" // Before the contact form in checkout.
 	| "modal_content" // Content of a modal dialog in checkout.
-	| "after_line_items_price"; // After the price of the line items in checkout.
+	| "after_line_items_price" // After the price of the line items in checkout.
+	| "before_shipping_form" // Before the shipping form in checkout.
+	| "after_shipping_form" // After the shipping form in checkout.
+	| "corner_top_left" // Top left corner of the checkout page.
+	| "corner_top_right" // Top right corner of the checkout page.
+	| "corner_bottom_left" // Bottom left corner of the checkout page.
+	| "corner_bottom_right"; // Bottom right corner of the checkout page.
 
 /**
  * Represents the value of a UI component, typically used for form inputs.


### PR DESCRIPTION
# Float Corners

This PR adds float corners slots for NubeSDK

Floating slots:

- `corner_top_left`
- `corner_top_right`
- `corner_bottom_left`
- `corner_bottom_right`

also includes the checkout start page slots:

- `before_shipping_form`
- `after_shipping_form`

Includes doc update and version bump


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added seven new UI slots for component placement in the checkout flow: after line items price, before and after the shipping form, and four corner positions.
- **Documentation**
  - Expanded and updated documentation in multiple languages to include the new UI slots and corrected example code.
- **Chores**
  - Updated package versions to 0.12.0 and 0.10.0 for related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->