### PR TITLE
feat: add autoFocus property to field and textarea components

### DIFF
--- a/packages/doc/docs/components/field.md
+++ b/packages/doc/docs/components/field.md
@@ -107,14 +107,15 @@ field({
 
 ## Properties
 
-| Property | Type                           | Required | Description                                          |
-| -------- | ------------------------------ | -------- | ---------------------------------------------------- |
-| name     | string                         | Yes      | The name of the field, used to identify it in forms. |
-| label    | string                         | Yes      | The label text displayed above the field.            |
-| value    | string                         | No       | The current value of the field input.                |
-| onChange | NubeComponentFieldEventHandler | No       | Function called when the field value changes.        |
-| onBlur   | NubeComponentFieldEventHandler | No       | Function called when the field loses focus.          |
-| onFocus  | NubeComponentFieldEventHandler | No       | Function called when the field receives focus.       |
+| Property | Type                           | Required | Description                                                        |
+| -------- | ------------------------------ | -------- | -------------------------------------------------------------------|
+| name     | string                         | Yes      | The name of the field, used to identify it in forms.               |
+| label    | string                         | Yes      | The label text displayed above the field.                          |
+| value    | string                         | No       | The current value of the field input.                              |
+| autoFocus| boolean                        | No       | Whether the field should automatically receive focus when mounted. |
+| onChange | NubeComponentFieldEventHandler | No       | Function called when the field value changes.                      |
+| onBlur   | NubeComponentFieldEventHandler | No       | Function called when the field loses focus.                        |
+| onFocus  | NubeComponentFieldEventHandler | No       | Function called when the field receives focus.                     |
 
 ### Property values
 

--- a/packages/doc/docs/components/textarea.md
+++ b/packages/doc/docs/components/textarea.md
@@ -115,16 +115,17 @@ textarea({
 
 ## Properties
 
-| Property  | Type                              | Required | Description                                                   |
-| --------- | --------------------------------- | -------- | ------------------------------------------------------------- |
-| name      | string                            | Yes      | The name of the textarea, used to identify it in forms.       |
-| label     | string                            | Yes      | The label text displayed above the textarea.                  |
-| value     | string                            | No       | The current value of the textarea.                            |
-| maxLength | number                            | No       | The maximum number of characters allowed in the textarea.     |
-| rows      | number                            | No       | The number of visible text lines in the textarea.             |
-| onChange  | NubeComponentTextareaEventHandler | No       | Function called when the textarea value changes.              |
-| onBlur    | NubeComponentTextareaEventHandler | No       | Function called when the textarea loses focus.                |
-| onFocus   | NubeComponentTextareaEventHandler | No       | Function called when the textarea receives focus.             |
+| Property  | Type                              | Required | Description                                                            |
+| --------- | --------------------------------- | -------- | -----------------------------------------------------------------------|
+| name      | string                            | Yes      | The name of the textarea, used to identify it in forms.                |
+| label     | string                            | Yes      | The label text displayed above the textarea.                           |
+| value     | string                            | No       | The current value of the textarea.                                     |
+| maxLength | number                            | No       | The maximum number of characters allowed in the textarea.              |
+| rows      | number                            | No       | The number of visible text lines in the textarea.                      |
+| autoFocus | boolean                           | No       | Whether the textarea should automatically receive focus when mounted.  |
+| onChange  | NubeComponentTextareaEventHandler | No       | Function called when the textarea value changes.                       |
+| onBlur    | NubeComponentTextareaEventHandler | No       | Function called when the textarea loses focus.                         |
+| onFocus   | NubeComponentTextareaEventHandler | No       | Function called when the textarea receives focus.                      |
 
 ### Property values
 

--- a/packages/doc/es/docs/components/field.md
+++ b/packages/doc/es/docs/components/field.md
@@ -112,6 +112,7 @@ field({
 | name      | string                         | Si         | El nombre del campo, usado para identificarlo en formularios. |
 | label     | string                         | Si         | El texto de la etiqueta mostrado encima del campo.            |
 | value     | string                         | No         | El valor actual del campo de entrada.                         |
+| autoFocus | boolean                        | No         | Indica si el campo debe recibir el foco automáticamente al montarse. |
 | onChange  | NubeComponentFieldEventHandler | No         | Función llamada cuando el valor del campo cambia.             |
 | onBlur    | NubeComponentFieldEventHandler | No         | Función llamada cuando el campo pierde el foco.               |
 | onFocus   | NubeComponentFieldEventHandler | No         | Función llamada cuando el campo recibe el foco.               |

--- a/packages/doc/es/docs/components/textarea.md
+++ b/packages/doc/es/docs/components/textarea.md
@@ -112,3 +112,23 @@ textarea({
   onFocus: handleEvents,
 });
 ```
+
+## Properties
+
+| Property  | Type                              | Required | Description                                                            |
+| --------- | --------------------------------- | -------- | -----------------------------------------------------------------------|
+| name      | string                            | Yes      | El nombre del textarea, usado para identificarlo en formularios.       |
+| label     | string                            | Yes      | El texto de la etiqueta mostrada encima del textarea.                  |
+| value     | string                            | No       | El valor actual del textarea.                                          |
+| maxLength | number                            | No       | El número máximo de caracteres permitidos en el textarea.              |
+| rows      | number                            | No       | El número de líneas de texto visibles en el textarea.                  |
+| autoFocus | boolean                           | No       | Si el textarea debe recibir el foco automáticamente al montarse.       |
+| onChange  | NubeComponentTextareaEventHandler | No       | Función llamada cuando cambia el valor del textarea.                   |
+| onBlur    | NubeComponentTextareaEventHandler | No       | Función llamada cuando el textarea pierde el foco.                     |
+| onFocus   | NubeComponentTextareaEventHandler | No       | Función llamada cuando el textarea recibe el foco.                     |
+
+### Property values
+
+| Type                              | Value                                                                                                         | Description                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| NubeComponentTextareaEventHandler | (data: {<br/>type: "change" \| "blur" \| "focus";<br/>state: NubeSDKState;<br/>value?: string;<br/>}) => void | Función manejadora de eventos del textarea. |

--- a/packages/doc/pt/docs/components/field.md
+++ b/packages/doc/pt/docs/components/field.md
@@ -112,6 +112,7 @@ field({
 | name        | string                         | Sim         | O nome do campo, usado para identificá-lo em formulários. |
 | label       | string                         | Sim         | O texto do rótulo exibido acima do campo.                 |
 | value       | string                         | Não         | O valor atual do campo de entrada.                        |
+| autoFocus   | boolean                        | Não         | Se o campo deve receber foco automaticamente quando montado. |
 | onChange    | NubeComponentFieldEventHandler | Não         | Função chamada quando o valor do campo muda.              |
 | onBlur      | NubeComponentFieldEventHandler | Não         | Função chamada quando o campo perde o foco.               |
 | onFocus     | NubeComponentFieldEventHandler | Não         | Função chamada quando o campo recebe o foco.              |

--- a/packages/doc/pt/docs/components/textarea.md
+++ b/packages/doc/pt/docs/components/textarea.md
@@ -112,3 +112,23 @@ textarea({
   onFocus: handleEvents,
 });
 ```
+
+## Properties
+
+| Property  | Type                              | Required | Description                                                            |
+| --------- | --------------------------------- | -------- | -----------------------------------------------------------------------|
+| name      | string                            | Yes      | O nome do textarea, usado para identificá-lo em formulários.           |
+| label     | string                            | Yes      | O texto do rótulo exibido acima do textarea.                           |
+| value     | string                            | No       | O valor atual do textarea.                                             |
+| maxLength | number                            | No       | O número máximo de caracteres permitidos no textarea.                  |
+| rows      | number                            | No       | O número de linhas de texto visíveis no textarea.                      |
+| autoFocus | boolean                           | No       | Se o textarea deve receber foco automaticamente quando montado.        |
+| onChange  | NubeComponentTextareaEventHandler | No       | Função chamada quando o valor do textarea muda.                        |
+| onBlur    | NubeComponentTextareaEventHandler | No       | Função chamada quando o textarea perde o foco.                         |
+| onFocus   | NubeComponentTextareaEventHandler | No       | Função chamada quando o textarea recebe foco.                          |
+
+### Property values
+
+| Type                              | Value                                                                                                         | Description                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| NubeComponentTextareaEventHandler | (data: {<br/>type: "change" \| "blur" \| "focus";<br/>state: NubeSDKState;<br/>value?: string;<br/>}) => void | Função manipuladora de eventos do textarea. |

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -145,6 +145,7 @@ export type NubeComponentFieldProps = Prettify<
 		name: string;
 		label: string;
 		value?: string;
+		autoFocus?: boolean;
 		onChange?: NubeComponentFieldEventHandler;
 		onBlur?: NubeComponentFieldEventHandler;
 		onFocus?: NubeComponentFieldEventHandler;
@@ -248,6 +249,7 @@ export type NubeComponentTextareaProps = Prettify<
 		maxLength?: number;
 		row?: number;
 		value?: string;
+		autoFocus?: boolean;
 		onChange?: NubeComponentTextareaEventHandler;
 		onBlur?: NubeComponentTextareaEventHandler;
 		onFocus?: NubeComponentTextareaEventHandler;


### PR DESCRIPTION
# Add autoFocus property to form components

## Description
This PR adds the `autoFocus` property to both `field` and `textarea` components, allowing them to automatically receive focus when mounted. This enhancement improves the user experience by enabling automatic focus on form elements when they are rendered.

## Changes
- Added `autoFocus` property to `NubeComponentFieldProps` and `NubeComponentTextareaProps` types
- Updated component documentation in multiple languages:
  - English
  - Spanish
  - Portuguese
- Added property description and type information in all language versions

## Technical Details
- Property type: `boolean`
- Optional property (not required)
- Default value: `undefined`

## Documentation
The property has been documented with the following description:
- English: "Whether the field/textarea should automatically receive focus when mounted"
- Spanish: "Indica si el campo debe recibir el foco automáticamente al montarse"
- Portuguese: "Se o campo deve receber foco automaticamente quando montado"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation for field and textarea components in English, Spanish, and Portuguese to include the new optional property `autoFocus`.
  - Enhanced properties tables and added detailed sections describing component properties and event handler types for textarea components.
- **New Features**
  - Introduced an optional `autoFocus` property for field and textarea components, allowing them to automatically receive focus when rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->