### PR TITLE
docs: add shipping:select event documentation

### DIFF
--- a/packages/doc/docs/events.md
+++ b/packages/doc/docs/events.md
@@ -218,6 +218,28 @@ nube.on("shipping:update", ({ shipping }) => {
 });
 ```
 
+## `shipping:select`
+
+Dispatched by `app` to select a shipping method. After dispatching this event, the store will respond with either `shipping:select:success` or `shipping:select:fail`.
+
+```typescript
+function App (nube: NubeSDK) {
+  nube.send("shipping:select", () => ({
+    shipping: {
+      selected: "ne-correios-sedex",
+    }
+  }));
+  
+  nube.on("shipping:select:success", ({ shipping }) => {
+    console.log("Selected option", shipping.selected)
+  });
+  
+  nube.on("shipping:select:fail", ({ shipping }) => {
+    console.log("Selected option", shipping.selected)
+  });
+}
+```
+
 ## `customer:update`
 
 Dispatched by `store` when the customer data changes.

--- a/packages/doc/es/docs/events.md
+++ b/packages/doc/es/docs/events.md
@@ -218,6 +218,28 @@ nube.on("shipping:update", ({ shipping }) => {
 });
 ```
 
+## `shipping:select`
+
+Disparado por la `app` para seleccionar un método de envío. Después de disparar este evento, la tienda responderá con `shipping:select:success` o `shipping:select:fail`.
+
+```typescript
+function App (nube: NubeSDK) {
+  nube.send("shipping:select", () => ({
+    shipping: {
+      selected: "ne-correios-sedex",
+    }
+  }));
+  
+  nube.on("shipping:select:success", ({ shipping }) => {
+    console.log("Selected option", shipping.selected)
+  });
+  
+  nube.on("shipping:select:fail", ({ shipping }) => {
+    console.log("Selected option", shipping.selected)
+  });
+}
+```
+
 ## `customer:update`
 
 Disparado por la `tienda` cuando los datos del cliente cambian.

--- a/packages/doc/pt/docs/events.md
+++ b/packages/doc/pt/docs/events.md
@@ -218,6 +218,28 @@ nube.on("shipping:update", ({ shipping }) => {
 });
 ```
 
+## `shipping:select`
+
+Disparado pelo `app` para selecionar um método de envio. Após disparar este evento, a loja responderá com `shipping:select:success` ou `shipping:select:fail`.
+
+```typescript
+function App (nube: NubeSDK) {
+  nube.send("shipping:select", () => ({
+    shipping: {
+      selected: "ne-correios-sedex",
+    }
+  }));
+  
+  nube.on("shipping:select:success", ({ shipping }) => {
+    console.log("Selected option", shipping.selected)
+  });
+  
+  nube.on("shipping:select:fail", ({ shipping }) => {
+    console.log("Selected option", shipping.selected)
+  });
+}
+```
+
 ## `customer:update`
 
 Disparado pela `loja` quando os dados do cliente mudam.


### PR DESCRIPTION
This pull request adds documentation for the new `shipping:select` event across multiple languages. The event allows the app to select a shipping method and receive a success or failure response. The changes include examples in TypeScript for how to use this event with the `NubeSDK`.

### Documentation Updates:

* **English Documentation (`packages/doc/docs/events.md`)**: Added a new section for the `shipping:select` event, including a description and a TypeScript example demonstrating how to send the event and handle success or failure responses.
* **Spanish Documentation (`packages/doc/es/docs/events.md`)**: Added the `shipping:select` event section with a description in Spanish and the same TypeScript example.
* **Portuguese Documentation (`packages/doc/pt/docs/events.md`)**: Added the `shipping:select` event section with a description in Portuguese and the same TypeScript example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for the new shipping method selection event (`shipping:select`) in English, Spanish, and Portuguese, including example usage and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->