### PR TITLE
feat(ui): release v0.6.0

### DIFF
--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,52 +1,64 @@
 {
-	"name": "@tiendanube/nube-sdk-jsx",
-	"version": "0.5.0",
-	"description": "Library for building JSX interfaces for NubeSDK",
-	"type": "module",
-	"main": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"exports": {
-		".": {
-			"import": {
-				"types": "./dist/index.d.ts",
-				"default": "./dist/index.js"
-			},
-			"require": "./dist/index.cjs"
-		},
-		"./jsx-runtime": {
-			"import": "./dist/jsx-runtime.ts"
-		},
-		"./jsx-dev-runtime": {
-			"import": "./dist/jsx-dev-runtime.ts"
-		},
-		"./dist/jsx-dev-runtime": {
-			"import": "./dist/jsx-dev-runtime.ts"
-		}
-	},
-	"scripts": {
-		"build": "tsup",
-		"check": "biome check src/*",
-		"check:fix": "biome check --write src/*"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/TiendaNube/nube-sdk.git"
-	},
-	"author": "Tiendanube / Nuvemshop",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/TiendaNube/nube-sdk/issues"
-	},
-	"homepage": "https://www.tiendanube.com",
-	"devDependencies": {
-		"@biomejs/biome": "1.8.3",
-		"tsup": "^8.3.5",
-		"typescript": "^5.6.2"
-	},
-	"peerDependencies": {
-		"@tiendanube/nube-sdk-types": "*",
-		"@tiendanube/nube-sdk-ui": "*"
-	},
-	"files": ["./dist", "README.md", "CHANGELOG.md", "LICENSE"],
-	"keywords": ["tiendanube", "nuvemshop", "nube-sdk", "ecommerce", "sdk", "jsx"]
+  "name": "@tiendanube/nube-sdk-jsx",
+  "version": "0.6.0",
+  "description": "Library for building JSX interfaces for NubeSDK",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": "./dist/index.cjs"
+    },
+    "./jsx-runtime": {
+      "import": "./dist/jsx-runtime.ts"
+    },
+    "./jsx-dev-runtime": {
+      "import": "./dist/jsx-dev-runtime.ts"
+    },
+    "./dist/jsx-dev-runtime": {
+      "import": "./dist/jsx-dev-runtime.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "biome check src/*",
+    "check:fix": "biome check --write src/*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TiendaNube/nube-sdk.git"
+  },
+  "author": "Tiendanube / Nuvemshop",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/TiendaNube/nube-sdk/issues"
+  },
+  "homepage": "https://www.tiendanube.com",
+  "devDependencies": {
+    "@biomejs/biome": "1.8.3",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.2"
+  },
+  "peerDependencies": {
+    "@tiendanube/nube-sdk-types": "*",
+    "@tiendanube/nube-sdk-ui": "*"
+  },
+  "files": [
+    "./dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "tiendanube",
+    "nuvemshop",
+    "nube-sdk",
+    "ecommerce",
+    "sdk",
+    "jsx"
+  ]
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,50 +1,50 @@
 {
-	"name": "@tiendanube/nube-sdk-ui",
-	"version": "0.5.0",
-	"description": "Library for building declarative interfaces for NubeSDK",
-	"type": "module",
-	"main": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"scripts": {
-		"build": "tsup",
-		"lint": "biome check src/*",
-		"format": "biome check --write src/*",
-		"test": "vitest run",
-		"test:watch": "vitest",
-		"test:coverage": "vitest run --coverage"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/TiendaNube/nube-sdk.git"
-	},
-	"author": "Tiendanube / Nuvemshop",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/TiendaNube/nube-sdk/issues"
-	},
-	"homepage": "https://www.tiendanube.com",
-	"devDependencies": {
-		"@biomejs/biome": "1.8.3",
-		"@vitest/coverage-v8": "^3.1.1",
-		"csstype": "^3.1.3",
-		"tsup": "^8.3.5",
-		"typescript": "^5.6.2",
-		"vitest": "^3.1.1"
-	},
-	"peerDependencies": {
-		"@tiendanube/nube-sdk-types": "*"
-	},
-	"files": [
-		"./dist",
-		"README.md",
-		"CHANGELOG.md",
-		"LICENSE"
-	],
-	"keywords": [
-		"tiendanube",
-		"nuvemshop",
-		"nube-sdk",
-		"ecommerce",
-		"sdk"
-	]
+  "name": "@tiendanube/nube-sdk-ui",
+  "version": "0.6.0",
+  "description": "Library for building declarative interfaces for NubeSDK",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "lint": "biome check src/*",
+    "format": "biome check --write src/*",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TiendaNube/nube-sdk.git"
+  },
+  "author": "Tiendanube / Nuvemshop",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/TiendaNube/nube-sdk/issues"
+  },
+  "homepage": "https://www.tiendanube.com",
+  "devDependencies": {
+    "@biomejs/biome": "1.8.3",
+    "@vitest/coverage-v8": "^3.1.1",
+    "csstype": "^3.1.3",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.2",
+    "vitest": "^3.1.1"
+  },
+  "peerDependencies": {
+    "@tiendanube/nube-sdk-types": "*"
+  },
+  "files": [
+    "./dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "tiendanube",
+    "nuvemshop",
+    "nube-sdk",
+    "ecommerce",
+    "sdk"
+  ]
 }


### PR DESCRIPTION
Bump versions of `nube-sdk-ui` and `nube-sdk-jsx` to `0.6.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package versions for improved consistency.
  - Reformatted package configuration files for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->