### PR TITLE
chore: bump create-nube-app to v0.14.0 and update SDK dependencies

### DIFF
--- a/packages/create-nube-app/package.json
+++ b/packages/create-nube-app/package.json
@@ -3,7 +3,7 @@
 	"description": "Create Nube App",
 	"author": "Tiendanube / Nuvemshop",
 	"license": "MIT",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"bin": {
 		"create-nube-app": "dist/index.js"
 	},

--- a/packages/create-nube-app/templates/minimal-ui-jsx/package.json
+++ b/packages/create-nube-app/templates/minimal-ui-jsx/package.json
@@ -14,8 +14,8 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-ui": "^0.5.0",
-		"@tiendanube/nube-sdk-jsx": "^0.5.0",
+		"@tiendanube/nube-sdk-ui": "^0.6.0",
+		"@tiendanube/nube-sdk-jsx": "^0.6.0",
 		"@tiendanube/nube-sdk-types": "^0.15.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",

--- a/packages/create-nube-app/templates/minimal-ui/package.json
+++ b/packages/create-nube-app/templates/minimal-ui/package.json
@@ -14,7 +14,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-ui": "^0.5.0",
+		"@tiendanube/nube-sdk-ui": "^0.6.0",
 		"@tiendanube/nube-sdk-types": "^0.15.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",


### PR DESCRIPTION
This pull request updates the versioning of the `create-nube-app` package and its associated templates to ensure compatibility with the latest SDK versions. The most important changes include bumping the package version and updating dependencies within the templates.

### Version updates:
* [`packages/create-nube-app/package.json`](diffhunk://#diff-09e5b03b5d9f43942f06538081c548be49b74a41f76d729d0d463f3659a9a214L6-R6): Updated the package version from `0.13.0` to `0.14.0`.

### Dependency updates:
* [`packages/create-nube-app/templates/minimal-ui-jsx/package.json`](diffhunk://#diff-1ef7e4b02e263a6cedc97eecb2ec4ee80b5bff65fc8bc6090a7ce707ee21e4ebL17-R18): Updated `@tiendanube/nube-sdk-ui` and `@tiendanube/nube-sdk-jsx` dependencies from `^0.5.0` to `^0.6.0`.
* [`packages/create-nube-app/templates/minimal-ui/package.json`](diffhunk://#diff-a2c6426e4907d86a0f8968b5b9ec91ba23a8664a8b90a6c49d20ebc4f17adba4L17-R17): Updated `@tiendanube/nube-sdk-ui` dependency from `^0.5.0` to `^0.6.0`.