### PR TITLE
feat(types): add granular styling support to select component

### DIFF
--- a/packages/create-nube-app/package.json
+++ b/packages/create-nube-app/package.json
@@ -3,7 +3,7 @@
 	"description": "Create Nube App",
 	"author": "Tiendanube / Nuvemshop",
 	"license": "MIT",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"bin": {
 		"create-nube-app": "dist/index.js"
 	},

--- a/packages/create-nube-app/templates/minimal-ui-jsx/package.json
+++ b/packages/create-nube-app/templates/minimal-ui-jsx/package.json
@@ -16,7 +16,7 @@
 		"@biomejs/biome": "^1.9.4",
 		"@tiendanube/nube-sdk-ui": "^0.8.0",
 		"@tiendanube/nube-sdk-jsx": "^0.8.0",
-		"@tiendanube/nube-sdk-types": "^0.17.0",
+		"@tiendanube/nube-sdk-types": "^0.17.1",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/create-nube-app/templates/minimal-ui/package.json
+++ b/packages/create-nube-app/templates/minimal-ui/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@tiendanube/nube-sdk-ui": "^0.8.0",
-		"@tiendanube/nube-sdk-types": "^0.17.0",
+		"@tiendanube/nube-sdk-types": "^0.17.1",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/create-nube-app/templates/minimal/package.json
+++ b/packages/create-nube-app/templates/minimal/package.json
@@ -13,7 +13,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-types": "^0.17.0",
+		"@tiendanube/nube-sdk-types": "^0.17.1",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.17.0",
+	"version": "0.17.1",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -284,6 +284,10 @@ export type NubeComponentSelectProps = Prettify<
 		name: string;
 		label: string;
 		value?: string;
+		style?: {
+			label?: NubeComponentStyle;
+			select?: NubeComponentStyle;
+		};
 		options: { label: string; value: string }[];
 		onChange?: NubeComponentSelectEventHandler;
 	}


### PR DESCRIPTION
# Add Styling Support to Select Component

## What Changed

Added optional `style` property to `NubeComponentSelectProps` to allow independent styling of label and select elements.

```typescript
style?: {
  label?: NubeComponentStyle;
  select?: NubeComponentStyle;
};
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom label and select styles in select component properties.
* **Chores**
  * Updated package versions across core and template packages for improved dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->