### PR TITLE
refactor(ui): standardize biome script names

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup",
-    "lint": "biome check src/*",
-    "format": "biome check --write src/*",
+    "check": "biome check src/*",
+    "check:fix": "biome check --write src/*",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION
# Standardize Biome Scripts Naming Convention

## What Changed
- Renamed `lint` script to `check` in `packages/ui/package.json`
- Renamed `format` script to `check:fix` in `packages/ui/package.json`

## Why
This change aligns the UI package with the naming convention already used across other packages in the monorepo (`types`, `create-nube-app`, `jsx`), ensuring consistency.

## Impact
- No functional changes
- Improves developer experience through consistent script naming
- Makes the codebase more maintainable

## Testing
- [x] Verified scripts work correctly
- [x] Confirmed alignment with other packages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed script commands for linting and formatting in the UI package to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->