### PR TITLE
fix(types): children definition

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -318,7 +318,7 @@ export type NubeComponentButtonEventHandler = NubeComponentEventHandler<
 export type NubeComponentButtonProps = Prettify<
 	NubeComponentBase &
 		Partial<{
-			children: string;
+			children: NubeComponentChildren;
 			disabled: boolean;
 			variant: "primary" | "secondary" | "transparent" | "link";
 			width: Size;
@@ -482,7 +482,7 @@ export type NubeComponentTextProps = Prettify<
 		modifiers?: TxtModifier[];
 		inline?: boolean;
 		style?: NubeComponentStyle;
-		children?: NubeComponent | NubeComponent[] | string;
+		children?: NubeComponentChildren;
 	}
 >;
 
@@ -797,7 +797,7 @@ export type NubeComponentBase = {
  * Defines components that can have child elements.
  */
 export type ChildrenProps = {
-	children?: NubeComponent | NubeComponent[];
+	children?: NubeComponentChildren;
 };
 
 /**
@@ -824,6 +824,14 @@ export type NubeComponent =
 	| NubeComponentToastTitle
 	| NubeComponentToastDescription
 	| NubeComponentIcon;
+
+/**
+ * Represents the children of a UI component.
+ */
+export type NubeComponentChildren =
+	| string
+	| NubeComponent
+	| (string | NubeComponent)[];
 
 /**
  * Represents components that can contain other components as children.


### PR DESCRIPTION
# fix(types): standardize children definition in components

This PR standardizes the `children` definition across all SDK components by creating a unified `NubeComponentChildren` type that accepts strings, individual components, or mixed arrays.

## Changes

- **New type**: Created `NubeComponentChildren` to standardize children typing
- **Fix**: Updated `children` definition in all components to use the new type
- **Compatibility**: Maintained compatibility with strings, individual components, and arrays
- **Formatting**: Improved code indentation and formatting


## Bump

- `packages/types/package.json` - Version bump to 0.18.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified type for component children, allowing greater flexibility when passing strings, single components, or arrays as children in component props.

* **Chores**
  * Updated the package version to 0.18.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->