### PR TITLE
fix(ui): improve stableStringify handling of non-string children

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Library for building declarative interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/src/components/generateInternalId.spec.ts
+++ b/packages/ui/src/components/generateInternalId.spec.ts
@@ -67,4 +67,28 @@ describe("generateInternalId", () => {
 
 		expect(id1).toBe(id2);
 	});
+
+	it("should handle non-string children props (arrays, objects, etc.)", () => {
+		const propsWithArrayChildren = {
+			children: ["item1", "item2"],
+			width: "100%",
+		};
+		const propsWithObjectChildren = {
+			children: { type: "element", value: "test" },
+			width: "100%",
+		};
+		const propsWithNumberChildren = {
+			children: 42,
+			width: "100%",
+		};
+
+		const id1 = generateInternalId("box", propsWithArrayChildren);
+		const id2 = generateInternalId("box", propsWithObjectChildren);
+		const id3 = generateInternalId("box", propsWithNumberChildren);
+
+		// All should generate the same ID because non-string children are normalized to "[children]"
+		expect(id1).toBe(id2);
+		expect(id2).toBe(id3);
+		expect(id1).toContain("box-test-app-id-");
+	});
 });

--- a/packages/ui/src/components/generateInternalId.ts
+++ b/packages/ui/src/components/generateInternalId.ts
@@ -6,7 +6,8 @@ const memo = new WeakMap<object, string>();
  * Serialize the props in a stable way, ignoring functions.
  */
 function stableStringify(value: unknown): string {
-	return JSON.stringify(value, (_key, val) => {
+	return JSON.stringify(value, (key, val) => {
+		if (key === "children" && typeof val !== "string") return "[children]";
 		if (typeof val === "function") return "[fn]";
 		return val;
 	});


### PR DESCRIPTION
# fix(ui): improve stableStringify handling of non-string children

This PR fix the cache system of render state to avoid full slot re-render.

## Before

https://github.com/user-attachments/assets/dea8c3d8-5c55-48a2-a4d0-0856d82e485c


## After

https://github.com/user-attachments/assets/0e9b73fd-0657-43bd-9a6c-160cebec851e







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-string values in the `children` property to ensure consistent internal ID generation.

* **Tests**
  * Added new test cases to verify correct behavior when `children` is an array, object, or number.

* **Chores**
  * Updated package version from 0.9.1 to 0.9.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->