### PR TITLE
fix(ui): include CSS in styled components internal ID generation

### DIFF
--- a/packages/create-nube-app/package.json
+++ b/packages/create-nube-app/package.json
@@ -3,7 +3,7 @@
 	"description": "Create Nube App",
 	"author": "Tiendanube / Nuvemshop",
 	"license": "MIT",
-	"version": "0.19.0",
+	"version": "0.19.1",
 	"bin": {
 		"create-nube-app": "dist/index.js"
 	},

--- a/packages/create-nube-app/templates/minimal-ui-jsx/package.json
+++ b/packages/create-nube-app/templates/minimal-ui-jsx/package.json
@@ -14,7 +14,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-ui": "^0.9.0",
+		"@tiendanube/nube-sdk-ui": "^0.9.3",
 		"@tiendanube/nube-sdk-jsx": "^0.9.0",
 		"@tiendanube/nube-sdk-types": "^0.18.0",
 		"@vitest/coverage-v8": "^3.0.9",

--- a/packages/create-nube-app/templates/minimal-ui/package.json
+++ b/packages/create-nube-app/templates/minimal-ui/package.json
@@ -14,7 +14,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-ui": "^0.9.0",
+		"@tiendanube/nube-sdk-ui": "^0.9.3",
 		"@tiendanube/nube-sdk-types": "^0.18.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-ui",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Library for building declarative interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/src/components/generateInternalId.spec.ts
+++ b/packages/ui/src/components/generateInternalId.spec.ts
@@ -91,4 +91,70 @@ describe("generateInternalId", () => {
 		expect(id2).toBe(id3);
 		expect(id1).toContain("box-test-app-id-");
 	});
+
+	describe("should reuse valid internal IDs", () => {
+		it("should return the same ID when a valid __internalId is provided", () => {
+			const validId = "box-test-app-id-abc123";
+			const props = {
+				__internalId: validId,
+				children: "test",
+				width: "100%",
+			};
+
+			const result = generateInternalId("box", props);
+			expect(result).toBe(validId);
+		});
+
+		it("should ignore invalid __internalId and generate a new one", () => {
+			const invalidId = "invalid-id-format";
+			const props = {
+				__internalId: invalidId,
+				children: "test",
+				width: "100%",
+			};
+
+			const result = generateInternalId("box", props);
+			expect(result).not.toBe(invalidId);
+			expect(result).toContain("box-test-app-id-");
+			expect(result).toMatch(/^box-test-app-id-[a-z0-9]+$/);
+		});
+
+		it("should ignore empty string __internalId and generate a new one", () => {
+			const props = {
+				__internalId: "",
+				children: "test",
+				width: "100%",
+			};
+
+			const result = generateInternalId("box", props);
+			expect(result).toContain("box-test-app-id-");
+			expect(result).toMatch(/^box-test-app-id-[a-z0-9]+$/);
+		});
+
+		it("should ignore non-string __internalId and generate a new one", () => {
+			const props = {
+				__internalId: 123,
+				children: "test",
+				width: "100%",
+			};
+
+			const result = generateInternalId("box", props);
+			expect(result).toContain("box-test-app-id-");
+			expect(result).toMatch(/^box-test-app-id-[a-z0-9]+$/);
+		});
+
+		it("should ignore __internalId with wrong app ID and generate a new one", () => {
+			const wrongAppId = "box-wrong-app-id-abc123";
+			const props = {
+				__internalId: wrongAppId,
+				children: "test",
+				width: "100%",
+			};
+
+			const result = generateInternalId("box", props);
+			expect(result).not.toBe(wrongAppId);
+			expect(result).toContain("box-test-app-id-");
+			expect(result).toMatch(/^box-test-app-id-[a-z0-9]+$/);
+		});
+	});
 });

--- a/packages/ui/src/components/generateInternalId.ts
+++ b/packages/ui/src/components/generateInternalId.ts
@@ -29,10 +29,30 @@ function createId(type: string, hash: string) {
 }
 
 /**
+ * Regular expression to validate the internal ID format: {type}-{appId}-{hash}
+ * - type: component type (letters, numbers, underscore, hyphen)
+ * - appId: application ID (alphanumeric)
+ * - hash: base36 hash (letters and numbers)
+ */
+function createInternalIdRegex(appId: string): RegExp {
+	// Escape special regex characters in appId
+	const escapedAppId = appId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(`^[a-zA-Z0-9_-]+-${escapedAppId}-[a-z0-9]+$`);
+}
+
+function isValidInternalId(id: unknown): id is string {
+	if (typeof id !== "string" || id === "") return false;
+
+	const regex = createInternalIdRegex(self.__APP_DATA__.id);
+	return regex.test(id);
+}
+
+/**
  * Generate a stable ID for a component based on the type and props.
  */
 export function generateInternalId(type: string, props: Props): string {
-	// Use cache based on the props reference
+	if (isValidInternalId(props.__internalId)) return props.__internalId;
+
 	const cached = memo.get(props);
 	if (cached) return createId(type, cached);
 

--- a/packages/ui/src/styles/styled-internalid.spec.ts
+++ b/packages/ui/src/styles/styled-internalid.spec.ts
@@ -1,0 +1,115 @@
+import type { NubeComponent } from "@tiendanube/nube-sdk-types";
+import { describe, expect, it } from "vitest";
+import { box } from "../components/box";
+import { text } from "../components/text";
+import { styled } from "./styled";
+
+type MountedComponent = NubeComponent & { __internalId: string };
+
+describe("Styled Components Internal ID Generation Bug", () => {
+	describe("when children are strings", () => {
+		describe("with components that have the same styles", () => {
+			const redComponent = styled(text)`background-color: red;`;
+			const anotherRedComponent = styled(text)`background-color: red;`;
+
+			it("should generate same internal IDs for the same string value", () => {
+				const children = "text";
+				expect(redComponent({ children })).toEqual(
+					anotherRedComponent({ children }),
+				);
+			});
+
+			it("should generate different internal IDs for different string values", () => {
+				const component1 = redComponent({
+					children: "Hello",
+				}) as MountedComponent;
+				const component2 = anotherRedComponent({
+					children: "World",
+				}) as MountedComponent;
+
+				expect(component1).not.toEqual(component2);
+				expect(component1.__internalId).not.toEqual(component2.__internalId);
+			});
+		});
+
+		describe("with components that have different styles", () => {
+			const redComponent = styled(text)`background-color: red;`;
+			const blueComponent = styled(text)`background-color: blue;`;
+
+			it("should generate different internal IDs for the same string value", () => {
+				const children = "text";
+				expect(redComponent({ children })).not.toEqual(
+					blueComponent({ children }),
+				);
+			});
+
+			it("should generate different internal IDs for the different string values", () => {
+				expect(redComponent({ children: "b" })).not.toEqual(
+					blueComponent({ children: "b" }),
+				);
+			});
+		});
+	});
+
+	describe("when children are components", () => {
+		describe("with components that have the same styles", () => {
+			const redBoxComponent = styled(box)`background-color: red;`;
+			const anotherRedBoxComponent = styled(box)`background-color: red;`;
+
+			it("should generate same internal IDs for the same component children", () => {
+				const children = text({ children: "text" });
+				expect(redBoxComponent({ children })).toEqual(
+					anotherRedBoxComponent({ children }),
+				);
+			});
+
+			it("should generate same internal IDs for the different component children", () => {
+				const childrenOne = text({ children: "one" });
+				const childrenTwo = text({ children: "two" });
+
+				const componentOne = redBoxComponent({
+					children: childrenOne,
+				}) as MountedComponent;
+				const componentTwo = anotherRedBoxComponent({
+					children: childrenTwo,
+				}) as MountedComponent;
+
+				expect(componentOne.__internalId).toEqual(componentTwo.__internalId);
+			});
+		});
+
+		describe("with components that have different styles", () => {
+			const redBoxComponent = styled(box)`background-color: red;`;
+			const blueBoxComponent = styled(box)`background-color: blue;`;
+
+			it("should generate different internal IDs for the same component children", () => {
+				const children = text({ children: "text" });
+
+				const redComponent = redBoxComponent({ children }) as MountedComponent;
+				const blueComponent = blueBoxComponent({
+					children,
+				}) as MountedComponent;
+
+				expect(redComponent.__internalId).not.toEqual(
+					blueComponent.__internalId,
+				);
+			});
+
+			it("should generate different internal IDs for the different component children", () => {
+				const childrenOne = text({ children: "one" });
+				const childrenTwo = text({ children: "two" });
+
+				const redComponent = redBoxComponent({
+					children: childrenOne,
+				}) as MountedComponent;
+				const blueComponent = blueBoxComponent({
+					children: childrenTwo,
+				}) as MountedComponent;
+
+				expect(redComponent.__internalId).not.toEqual(
+					blueComponent.__internalId,
+				);
+			});
+		});
+	});
+});

--- a/packages/ui/src/styles/styled.ts
+++ b/packages/ui/src/styles/styled.ts
@@ -2,6 +2,7 @@ import type {
 	NubeComponent,
 	NubeComponentProps,
 } from "@tiendanube/nube-sdk-types";
+import { generateInternalId } from "../components/generateInternalId";
 import { isKeyframesObject } from "./keyframes";
 import { minify } from "./minify";
 
@@ -22,9 +23,6 @@ export function styled<Props extends NubeComponentProps>(
 ) {
 	return (strings: TemplateStringsArray, ...exprs: unknown[]) => {
 		const StyledComponent: NubeComponentFunction<Props> = (props) => {
-			const component = baseComponent(props);
-			if (typeof component === "string") return component;
-
 			let rawCSS = "";
 			const animation: string[] = [];
 
@@ -43,6 +41,19 @@ export function styled<Props extends NubeComponentProps>(
 
 			const minifiedCSS = minify(`${animation.join("")}${rawCSS}`);
 
+			const componentType = baseComponent.name || "component";
+
+			const internalId = generateInternalId(componentType, {
+				...props,
+				__styledCSS: minifiedCSS,
+			});
+
+			// Create the base component with pre-generated ID
+			const component = baseComponent({ ...props, __internalId: internalId });
+
+			if (typeof component === "string") return component;
+
+			// Apply the styled CSS
 			component.styled = `${component.styled || ""}${minifiedCSS}`;
 
 			return component;


### PR DESCRIPTION
Fixes rendering issues where styled components with identical props but different CSS would generate the same internal ID, causing problems in the host rendering system.

- Fix duplicate internal IDs for styled components with same props but different CSS
- Include minified CSS in ID hash calculation via __styledCSS prop
- Add pre-generated ID support in generateInternalId() function
- Refactor styled() execution order to generate ID before component creation
- Add comprehensive test suite covering string/component children scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of styled-component IDs to avoid collisions—identical styles now reuse IDs; differing styles produce distinct IDs.
  * Support for validated internal-ID overrides via component props so valid supplied IDs are reused.

* **Tests**
  * Added tests covering internal-ID handling and styled-component ID behavior across string and component children.

* **Chores**
  * Bumped package versions (UI and starter templates) and updated related devDependency references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->