### PR TITLE
feat(types): add ui slots for storefront

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.18.1",
+	"version": "0.19.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -841,12 +841,17 @@ export type NubeComponentWithChildren =
 	| NubeComponentColumn
 	| NubeComponentRow;
 
-/**
- * Represents a UI slot where components can be dynamically injected.
- */
-export type UISlot =
+export type CommonUISlot =
 	| "before_main_content" // Before the main checkout content.
 	| "after_main_content" // After the main checkout content.
+	| "modal_content" // Content of a modal dialog in checkout.
+	| "corner_top_left" // Top left corner of the checkout page.
+	| "corner_top_right" // Top right corner of the checkout page.
+	| "corner_bottom_left" // Bottom left corner of the checkout page.
+	| "corner_bottom_right"; // Bottom right corner of the checkout page.
+
+export type CheckoutUISlot =
+	| CommonUISlot
 	| "before_line_items" // Before the list of items in the cart.
 	| "after_line_items" // After the list of items in the cart.
 	| "after_contact_form" // After the contact form in checkout.
@@ -857,14 +862,27 @@ export type UISlot =
 	| "before_address_form" // Before the address form in checkout.
 	| "before_billing_form" // Before the billing form in checkout.
 	| "before_contact_form" // Before the contact form in checkout.
-	| "modal_content" // Content of a modal dialog in checkout.
 	| "after_line_items_price" // After the price of the line items in checkout.
 	| "before_shipping_form" // Before the shipping form in checkout.
-	| "after_shipping_form" // After the shipping form in checkout.
-	| "corner_top_left" // Top left corner of the checkout page.
-	| "corner_top_right" // Top right corner of the checkout page.
-	| "corner_bottom_left" // Bottom left corner of the checkout page.
-	| "corner_bottom_right"; // Bottom right corner of the checkout page.
+	| "after_shipping_form"; // After the shipping form in checkout.
+
+export type StorefrontUISlot =
+	| CommonUISlot
+	| "before_quick_buy_add_to_cart"
+	| "before_product_detail_add_to_cart"
+	| "after_product_detail_add_to_cart"
+	| "product_detail_image_top_left"
+	| "product_detail_image_top_right"
+	| "after_product_grid_item_name"
+	| "product_grid_item_image_top_right"
+	| "product_grid_item_image_top_left"
+	| "product_grid_item_image_bottom_right"
+	| "product_grid_item_image_bottom_left";
+
+/**
+ * Represents a UI slot where components can be dynamically injected.
+ */
+export type UISlot = Prettify<CheckoutUISlot | StorefrontUISlot>;
 
 /**
  * Represents the value of a UI component, typically used for form inputs.

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -36,7 +36,7 @@ export type Product = {
 	sku: Nullable<string>;
 
 	/** Additional properties related to the product (structure unknown). */
-	properties: Array<unknown>;
+	properties: Array<unknown> | Record<string, unknown>;
 
 	/** URL of the product's page. */
 	url: string;


### PR DESCRIPTION
This PR add new slot types for storefront

```ts
export type StorefrontUISlot =
	| CommonUISlot
	| "before_quick_buy_add_to_cart"
	| "before_product_detail_add_to_cart"
	| "after_product_detail_add_to_cart"
	| "product_detail_image_top_left"
	| "product_detail_image_top_right"
	| "after_product_grid_item_name"
	| "product_grid_item_image_top_right"
	| "product_grid_item_image_top_left"
	| "product_grid_item_image_bottom_right"
	| "product_grid_item_image_bottom_left";
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct UI slot contexts for Checkout and Storefront, with a shared common set for modals and corner placements.
  * Expanded slot coverage: new storefront slots around product detail and grid images, and additional checkout slots before/after key forms, line items, and payment/shipping sections.
  * Product properties now accept either an array or a key–value map for greater flexibility.

* **Chores**
  * Version bumped to 0.19.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->