### PR TITLE
refactor(types): centralize UI slot definitions

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.19.1",
+	"version": "0.20.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -1,5 +1,6 @@
 import type { NubeComponentStyle } from "@tiendanube/nube-sdk-ui";
 import type { NubeSDKState } from "./main";
+import type { UISlot } from "./slots";
 import type { Prettify } from "./utility";
 
 /* -------------------------------------------------------------------------- */
@@ -840,49 +841,6 @@ export type NubeComponentWithChildren =
 	| NubeComponentBox
 	| NubeComponentColumn
 	| NubeComponentRow;
-
-export type CommonUISlot =
-	| "before_main_content" // Before the main checkout content.
-	| "after_main_content" // After the main checkout content.
-	| "modal_content" // Content of a modal dialog in checkout.
-	| "corner_top_left" // Top left corner of the checkout page.
-	| "corner_top_right" // Top right corner of the checkout page.
-	| "corner_bottom_left" // Bottom left corner of the checkout page.
-	| "corner_bottom_right"; // Bottom right corner of the checkout page.
-
-export type CheckoutUISlot =
-	| CommonUISlot
-	| "before_line_items" // Before the list of items in the cart.
-	| "after_line_items" // After the list of items in the cart.
-	| "after_contact_form" // After the contact form in checkout.
-	| "after_address_form" // After the address form in checkout.
-	| "after_billing_form" // After the billing form in checkout.
-	| "after_payment_options" // After the payment options in checkout.
-	| "before_payment_options" // Before the payment options in checkout.
-	| "before_address_form" // Before the address form in checkout.
-	| "before_billing_form" // Before the billing form in checkout.
-	| "before_contact_form" // Before the contact form in checkout.
-	| "after_line_items_price" // After the price of the line items in checkout.
-	| "before_shipping_form" // Before the shipping form in checkout.
-	| "after_shipping_form"; // After the shipping form in checkout.
-
-export type StorefrontUISlot =
-	| CommonUISlot
-	| "before_quick_buy_add_to_cart"
-	| "before_product_detail_add_to_cart"
-	| "after_product_detail_add_to_cart"
-	| "product_detail_image_top_left"
-	| "product_detail_image_top_right"
-	| "after_product_grid_item_name"
-	| "product_grid_item_image_top_right"
-	| "product_grid_item_image_top_left"
-	| "product_grid_item_image_bottom_right"
-	| "product_grid_item_image_bottom_left";
-
-/**
- * Represents a UI slot where components can be dynamically injected.
- */
-export type UISlot = Prettify<CheckoutUISlot | StorefrontUISlot>;
 
 /**
  * Represents the value of a UI component, typically used for form inputs.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,3 +6,10 @@ export type * from "./storage";
 export * from "./internal";
 export type * from "./events";
 export { EVENT, SENDABLE_EVENT } from "./events";
+export type * from "./slots";
+export {
+	COMMON_UI_SLOT,
+	CHECKOUT_UI_SLOT,
+	STOREFRONT_UI_SLOT,
+	UI_SLOT,
+} from "./slots";

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -1,5 +1,5 @@
 import type { NubeBrowserAPIs } from "./browser";
-import type { NubeComponent, UI, UISlot } from "./components";
+import type { NubeComponent, UI } from "./components";
 import type {
 	AppConfig,
 	AppLocation,
@@ -10,6 +10,7 @@ import type {
 	Store,
 } from "./domain";
 import type { NubeSDKListenableEvent, NubeSDKSendableEvent } from "./events";
+import type { UISlot } from "./slots";
 import type { DeepPartial, Nullable } from "./utility";
 
 /**

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -1,0 +1,143 @@
+import type { ObjectValues, Prettify } from "./utility";
+
+/**
+ * List of common UI slots available across different contexts.
+ *
+ * These slots are shared between checkout and storefront interfaces,
+ * providing consistent placement options for UI components.
+ *
+ * @constant
+ *
+ * @property {"before_main_content"} BEFORE_MAIN_CONTENT - Before the main content area.
+ * @property {"after_main_content"} AFTER_MAIN_CONTENT - After the main content area.
+ * @property {"modal_content"} MODAL_CONTENT - Content of a modal dialog.
+ * @property {"corner_top_left"} CORNER_TOP_LEFT - Top left corner of the page.
+ * @property {"corner_top_right"} CORNER_TOP_RIGHT - Top right corner of the page.
+ * @property {"corner_bottom_left"} CORNER_BOTTOM_LEFT - Bottom left corner of the page.
+ * @property {"corner_bottom_right"} CORNER_BOTTOM_RIGHT - Bottom right corner of the page.
+ */
+export const COMMON_UI_SLOT = {
+	BEFORE_MAIN_CONTENT: "before_main_content",
+	AFTER_MAIN_CONTENT: "after_main_content",
+	MODAL_CONTENT: "modal_content",
+	CORNER_TOP_LEFT: "corner_top_left",
+	CORNER_TOP_RIGHT: "corner_top_right",
+	CORNER_BOTTOM_LEFT: "corner_bottom_left",
+	CORNER_BOTTOM_RIGHT: "corner_bottom_right",
+} as const;
+
+/**
+ * List of UI slots available in the checkout context.
+ *
+ * These slots provide specific placement options for UI components
+ * during the checkout process, allowing customization of forms,
+ * payment options, and item displays.
+ *
+ * @constant
+ *
+ * @property {"before_line_items"} BEFORE_LINE_ITEMS - Before the list of items in the cart.
+ * @property {"after_line_items"} AFTER_LINE_ITEMS - After the list of items in the cart.
+ * @property {"after_contact_form"} AFTER_CONTACT_FORM - After the contact form in checkout.
+ * @property {"after_address_form"} AFTER_ADDRESS_FORM - After the address form in checkout.
+ * @property {"after_billing_form"} AFTER_BILLING_FORM - After the billing form in checkout.
+ * @property {"after_payment_options"} AFTER_PAYMENT_OPTIONS - After the payment options in checkout.
+ * @property {"before_payment_options"} BEFORE_PAYMENT_OPTIONS - Before the payment options in checkout.
+ * @property {"before_address_form"} BEFORE_ADDRESS_FORM - Before the address form in checkout.
+ * @property {"before_billing_form"} BEFORE_BILLING_FORM - Before the billing form in checkout.
+ * @property {"before_contact_form"} BEFORE_CONTACT_FORM - Before the contact form in checkout.
+ * @property {"after_line_items_price"} AFTER_LINE_ITEMS_PRICE - After the price of the line items in checkout.
+ * @property {"before_shipping_form"} BEFORE_SHIPPING_FORM - Before the shipping form in checkout.
+ * @property {"after_shipping_form"} AFTER_SHIPPING_FORM - After the shipping form in checkout.
+ * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
+ */
+export const CHECKOUT_UI_SLOT = {
+	...COMMON_UI_SLOT,
+	BEFORE_LINE_ITEMS: "before_line_items",
+	AFTER_LINE_ITEMS: "after_line_items",
+	AFTER_CONTACT_FORM: "after_contact_form",
+	AFTER_ADDRESS_FORM: "after_address_form",
+	AFTER_BILLING_FORM: "after_billing_form",
+	AFTER_PAYMENT_OPTIONS: "after_payment_options",
+	BEFORE_PAYMENT_OPTIONS: "before_payment_options",
+	BEFORE_ADDRESS_FORM: "before_address_form",
+	BEFORE_BILLING_FORM: "before_billing_form",
+	BEFORE_CONTACT_FORM: "before_contact_form",
+	AFTER_LINE_ITEMS_PRICE: "after_line_items_price",
+	BEFORE_SHIPPING_FORM: "before_shipping_form",
+	AFTER_SHIPPING_FORM: "after_shipping_form",
+} as const;
+
+/**
+ * List of UI slots available in the storefront context.
+ *
+ * These slots provide specific placement options for UI components
+ * in product pages and storefronts, allowing customization of
+ * product displays, add to cart buttons, and grid layouts.
+ *
+ * @constant
+ *
+ * @property {"before_quick_buy_add_to_cart"} BEFORE_QUICK_BUY_ADD_TO_CART - Before the quick buy add to cart button.
+ * @property {"before_product_detail_add_to_cart"} BEFORE_PRODUCT_DETAIL_ADD_TO_CART - Before the product detail add to cart button.
+ * @property {"after_product_detail_add_to_cart"} AFTER_PRODUCT_DETAIL_ADD_TO_CART - After the product detail add to cart button.
+ * @property {"product_detail_image_top_left"} PRODUCT_DETAIL_IMAGE_TOP_LEFT - Top left corner of product detail images.
+ * @property {"product_detail_image_top_right"} PRODUCT_DETAIL_IMAGE_TOP_RIGHT - Top right corner of product detail images.
+ * @property {"after_product_grid_item_name"} AFTER_PRODUCT_GRID_ITEM_NAME - After the product name in grid items.
+ * @property {"product_grid_item_image_top_right"} PRODUCT_GRID_ITEM_IMAGE_TOP_RIGHT - Top right corner of product grid item images.
+ * @property {"product_grid_item_image_top_left"} PRODUCT_GRID_ITEM_IMAGE_TOP_LEFT - Top left corner of product grid item images.
+ * @property {"product_grid_item_image_bottom_right"} PRODUCT_GRID_ITEM_IMAGE_BOTTOM_RIGHT - Bottom right corner of product grid item images.
+ * @property {"product_grid_item_image_bottom_left"} PRODUCT_GRID_ITEM_IMAGE_BOTTOM_LEFT - Bottom left corner of product grid item images.
+ * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
+ */
+export const STOREFRONT_UI_SLOT = {
+	...COMMON_UI_SLOT,
+	BEFORE_QUICK_BUY_ADD_TO_CART: "before_quick_buy_add_to_cart",
+	BEFORE_PRODUCT_DETAIL_ADD_TO_CART: "before_product_detail_add_to_cart",
+	AFTER_PRODUCT_DETAIL_ADD_TO_CART: "after_product_detail_add_to_cart",
+	PRODUCT_DETAIL_IMAGE_TOP_LEFT: "product_detail_image_top_left",
+	PRODUCT_DETAIL_IMAGE_TOP_RIGHT: "product_detail_image_top_right",
+	AFTER_PRODUCT_GRID_ITEM_NAME: "after_product_grid_item_name",
+	PRODUCT_GRID_ITEM_IMAGE_TOP_RIGHT: "product_grid_item_image_top_right",
+	PRODUCT_GRID_ITEM_IMAGE_TOP_LEFT: "product_grid_item_image_top_left",
+	PRODUCT_GRID_ITEM_IMAGE_BOTTOM_RIGHT: "product_grid_item_image_bottom_right",
+	PRODUCT_GRID_ITEM_IMAGE_BOTTOM_LEFT: "product_grid_item_image_bottom_left",
+} as const;
+
+/**
+ * Combined list of all available UI slots.
+ *
+ * This object merges all checkout and storefront UI slots,
+ * providing a unified interface for accessing any UI slot.
+ *
+ * @constant
+ *
+ * @property {...typeof CHECKOUT_UI_SLOT} - Includes all checkout UI slots.
+ * @property {...typeof STOREFRONT_UI_SLOT} - Includes all storefront UI slots.
+ */
+export const UI_SLOT = {
+	...CHECKOUT_UI_SLOT,
+	...STOREFRONT_UI_SLOT,
+} as const;
+
+/**
+ * Represents the possible common UI slots that can be used across different contexts.
+ * These slots are available in both checkout and storefront interfaces.
+ */
+export type CommonUISlot = ObjectValues<typeof COMMON_UI_SLOT>;
+
+/**
+ * Represents the possible UI slots that can be used in the checkout context.
+ * Includes all common slots plus checkout-specific slots.
+ */
+export type CheckoutUISlot = ObjectValues<typeof CHECKOUT_UI_SLOT>;
+
+/**
+ * Represents the possible UI slots that can be used in the storefront context.
+ * Includes all common slots plus storefront-specific slots.
+ */
+export type StorefrontUISlot = ObjectValues<typeof STOREFRONT_UI_SLOT>;
+
+/**
+ * Represents all possible UI slots where components can be dynamically injected.
+ * This type combines checkout, storefront, and common UI slots.
+ */
+export type UISlot = Prettify<CheckoutUISlot | StorefrontUISlot>;


### PR DESCRIPTION
## 📋 Changes

- Export `COMMON_UI_SLOT`, `CHECKOUT_UI_SLOT`, `STOREFRONT_UI_SLOT` constants
- Enable developers to use type-safe constants instead of magic strings
- Maintain full backward compatibility with existing type definitions

## 🔄 Usage

```tsx
// ✅ New constants to avoid magic strings
import { CHECKOUT_UI_SLOT } from "@tiendanube/nube-sdk-types";

nube.render(CHECKOUT_UI_SLOT.AFTER_LINE_ITEMS, <MyComponent />)

// ✅ Existing usage still works
nube.render("after_line_items", <MyComponent />)
```
## 📦 What's Included

- 30 UI slot constants across Common, Checkout, and Storefront contexts
- Comprehensive JSDoc for all slot definitions
- Zero breaking changes to existing API
- package bump to 0.20.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, strongly-typed catalog of UI slot identifiers for common, checkout, and storefront contexts.
  * Slot constants and types are now exported from the package root for simpler, consistent imports and usage.
  * Existing render/API signatures remain unchanged while slot usage is standardized.

* **Chores**
  * Package version bumped to 0.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->