### PR TITLE
Feat: Add Payload to Success Events listeners in types package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9559,7 +9559,7 @@
       }
     },
     "packages/create-nube-app": {
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
@@ -10133,7 +10133,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.18.0",
+      "version": "0.21.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10305,7 +10305,7 @@
     },
     "packages/ui": {
       "name": "@tiendanube/nube-sdk-ui",
-      "version": "0.9.0",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.20.1",
+	"version": "0.21.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -24,15 +24,15 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  * @property {"shipping:select"} SHIPPING_SELECT - Used to select shipping option.
  */
 export const SENDABLE_EVENT = {
-  CART_VALIDATE: "cart:validate",
-  CART_ADD: "cart:add",
-  CART_REMOVE: "cart:remove",
-  CONFIG_SET: "config:set",
-  UI_SLOT_SET: "ui:slot:set",
-  SHIPPING_UPDATE_LABEL: "shipping:update:label",
-  COUPON_ADD: "coupon:add",
-  COUPON_REMOVE: "coupon:remove",
-  SHIPPING_SELECT: "shipping:select",
+	CART_VALIDATE: "cart:validate",
+	CART_ADD: "cart:add",
+	CART_REMOVE: "cart:remove",
+	CONFIG_SET: "config:set",
+	UI_SLOT_SET: "ui:slot:set",
+	SHIPPING_UPDATE_LABEL: "shipping:update:label",
+	COUPON_ADD: "coupon:add",
+	COUPON_REMOVE: "coupon:remove",
+	SHIPPING_SELECT: "shipping:select",
 } as const;
 
 /**
@@ -40,7 +40,7 @@ export const SENDABLE_EVENT = {
  * These events trigger specific actions within the SDK.
  */
 export type NubeSDKSendableEvent = Prettify<
-  ObjectValues<typeof SENDABLE_EVENT> | NubeSDKCustomEvent
+	ObjectValues<typeof SENDABLE_EVENT> | NubeSDKCustomEvent
 >;
 
 /**
@@ -73,34 +73,34 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
-  ALL: "*",
-  PAGE_LOADED: "page:loaded",
-  CART_UPDATE: "cart:update",
-  CART_ADD_SUCCESS: "cart:add:success",
-  CART_REMOVE_SUCCESS: "cart:remove:success",
-  CART_ADD_FAIL: "cart:add:fail",
-  CART_REMOVE_FAIL: "cart:remove:fail",
-  CHECKOUT_READY: "checkout:ready",
-  CHECKOUT_SUCCESS: "checkout:success",
-  SHIPPING_UPDATE: "shipping:update",
-  SHIPPING_SELECT_SUCCESS: "shipping:select:success",
-  SHIPPING_SELECT_FAIL: "shipping:select:fail",
-  CUSTOMER_UPDATE: "customer:update",
-  PAYMENT_UPDATE: "payment:update",
-  COUPON_ADD_SUCCESS: "coupon:add:success",
-  COUPON_REMOVE_SUCCESS: "coupon:remove:success",
-  COUPON_ADD_FAIL: "coupon:add:fail",
-  COUPON_REMOVE_FAIL: "coupon:remove:fail",
-  LOCATION_UPDATED: "location:updated",
-  ...SENDABLE_EVENT,
+	ALL: "*",
+	PAGE_LOADED: "page:loaded",
+	CART_UPDATE: "cart:update",
+	CART_ADD_SUCCESS: "cart:add:success",
+	CART_REMOVE_SUCCESS: "cart:remove:success",
+	CART_ADD_FAIL: "cart:add:fail",
+	CART_REMOVE_FAIL: "cart:remove:fail",
+	CHECKOUT_READY: "checkout:ready",
+	CHECKOUT_SUCCESS: "checkout:success",
+	SHIPPING_UPDATE: "shipping:update",
+	SHIPPING_SELECT_SUCCESS: "shipping:select:success",
+	SHIPPING_SELECT_FAIL: "shipping:select:fail",
+	CUSTOMER_UPDATE: "customer:update",
+	PAYMENT_UPDATE: "payment:update",
+	COUPON_ADD_SUCCESS: "coupon:add:success",
+	COUPON_REMOVE_SUCCESS: "coupon:remove:success",
+	COUPON_ADD_FAIL: "coupon:add:fail",
+	COUPON_REMOVE_FAIL: "coupon:remove:fail",
+	LOCATION_UPDATED: "location:updated",
+	...SENDABLE_EVENT,
 } as const;
 
 /**
  * Represents the possible events that can be listened to within NubeSDK that end with :success.
  */
 export type SuccessEvents = Extract<
-  NubeSDKListenableEvent,
-  `${string}:success`
+	NubeSDKListenableEvent,
+	`${string}:success`
 >;
 
 /**
@@ -108,5 +108,5 @@ export type SuccessEvents = Extract<
  * These events notify the application about changes in state or actions.
  */
 export type NubeSDKListenableEvent = Prettify<
-  ObjectValues<typeof EVENT> | NubeSDKCustomEvent
+	ObjectValues<typeof EVENT> | NubeSDKCustomEvent
 >;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -24,15 +24,15 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  * @property {"shipping:select"} SHIPPING_SELECT - Used to select shipping option.
  */
 export const SENDABLE_EVENT = {
-	CART_VALIDATE: "cart:validate",
-	CART_ADD: "cart:add",
-	CART_REMOVE: "cart:remove",
-	CONFIG_SET: "config:set",
-	UI_SLOT_SET: "ui:slot:set",
-	SHIPPING_UPDATE_LABEL: "shipping:update:label",
-	COUPON_ADD: "coupon:add",
-	COUPON_REMOVE: "coupon:remove",
-	SHIPPING_SELECT: "shipping:select",
+  CART_VALIDATE: "cart:validate",
+  CART_ADD: "cart:add",
+  CART_REMOVE: "cart:remove",
+  CONFIG_SET: "config:set",
+  UI_SLOT_SET: "ui:slot:set",
+  SHIPPING_UPDATE_LABEL: "shipping:update:label",
+  COUPON_ADD: "coupon:add",
+  COUPON_REMOVE: "coupon:remove",
+  SHIPPING_SELECT: "shipping:select",
 } as const;
 
 /**
@@ -40,7 +40,7 @@ export const SENDABLE_EVENT = {
  * These events trigger specific actions within the SDK.
  */
 export type NubeSDKSendableEvent = Prettify<
-	ObjectValues<typeof SENDABLE_EVENT> | NubeSDKCustomEvent
+  ObjectValues<typeof SENDABLE_EVENT> | NubeSDKCustomEvent
 >;
 
 /**
@@ -73,32 +73,40 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
-	ALL: "*",
-	PAGE_LOADED: "page:loaded",
-	CART_UPDATE: "cart:update",
-	CART_ADD_SUCCESS: "cart:add:success",
-	CART_REMOVE_SUCCESS: "cart:remove:success",
-	CART_ADD_FAIL: "cart:add:fail",
-	CART_REMOVE_FAIL: "cart:remove:fail",
-	CHECKOUT_READY: "checkout:ready",
-	CHECKOUT_SUCCESS: "checkout:success",
-	SHIPPING_UPDATE: "shipping:update",
-	SHIPPING_SELECT_SUCCESS: "shipping:select:success",
-	SHIPPING_SELECT_FAIL: "shipping:select:fail",
-	CUSTOMER_UPDATE: "customer:update",
-	PAYMENT_UPDATE: "payment:update",
-	COUPON_ADD_SUCCESS: "coupon:add:success",
-	COUPON_REMOVE_SUCCESS: "coupon:remove:success",
-	COUPON_ADD_FAIL: "coupon:add:fail",
-	COUPON_REMOVE_FAIL: "coupon:remove:fail",
-	LOCATION_UPDATED: "location:updated",
-	...SENDABLE_EVENT,
+  ALL: "*",
+  PAGE_LOADED: "page:loaded",
+  CART_UPDATE: "cart:update",
+  CART_ADD_SUCCESS: "cart:add:success",
+  CART_REMOVE_SUCCESS: "cart:remove:success",
+  CART_ADD_FAIL: "cart:add:fail",
+  CART_REMOVE_FAIL: "cart:remove:fail",
+  CHECKOUT_READY: "checkout:ready",
+  CHECKOUT_SUCCESS: "checkout:success",
+  SHIPPING_UPDATE: "shipping:update",
+  SHIPPING_SELECT_SUCCESS: "shipping:select:success",
+  SHIPPING_SELECT_FAIL: "shipping:select:fail",
+  CUSTOMER_UPDATE: "customer:update",
+  PAYMENT_UPDATE: "payment:update",
+  COUPON_ADD_SUCCESS: "coupon:add:success",
+  COUPON_REMOVE_SUCCESS: "coupon:remove:success",
+  COUPON_ADD_FAIL: "coupon:add:fail",
+  COUPON_REMOVE_FAIL: "coupon:remove:fail",
+  LOCATION_UPDATED: "location:updated",
+  ...SENDABLE_EVENT,
 } as const;
+
+/**
+ * Represents the possible events that can be listened to within NubeSDK that end with :success.
+ */
+export type SuccessEvents = Extract<
+  NubeSDKListenableEvent,
+  `${string}:success`
+>;
 
 /**
  * Represents the possible events that can be listened to within NubeSDK.
  * These events notify the application about changes in state or actions.
  */
 export type NubeSDKListenableEvent = Prettify<
-	ObjectValues<typeof EVENT> | NubeSDKCustomEvent
+  ObjectValues<typeof EVENT> | NubeSDKCustomEvent
 >;

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -1,68 +1,68 @@
 import type { NubeBrowserAPIs } from "./browser";
 import type { NubeComponent, UI } from "./components";
 import type {
-  AppConfig,
-  AppLocation,
-  Cart,
-  Customer,
-  Payment,
-  Shipping,
-  Store,
+	AppConfig,
+	AppLocation,
+	Cart,
+	Customer,
+	Payment,
+	Shipping,
+	Store,
 } from "./domain";
 import type {
-  NubeSDKListenableEvent,
-  NubeSDKSendableEvent,
-  SuccessEvents,
+	NubeSDKListenableEvent,
+	NubeSDKSendableEvent,
+	SuccessEvents,
 } from "./events";
+
 import type { UISlot } from "./slots";
 import type { DeepPartial, Nullable } from "./utility";
-import { SENDABLE_EVENT } from "./events";
 
 /**
  * Represents the current state of the NubeSDK.
  * This state is immutable and contains all relevant application data.
  */
 export type NubeSDKState = {
-  /**
-   * The current cart state, containing products, pricing, and validation status.
-   */
-  cart: Cart;
+	/**
+	 * The current cart state, containing products, pricing, and validation status.
+	 */
+	cart: Cart;
 
-  /**
-   * Application-wide configuration settings, including cart validation rules.
-   */
-  config: AppConfig;
+	/**
+	 * Application-wide configuration settings, including cart validation rules.
+	 */
+	config: AppConfig;
 
-  /**
-   * The user's current location within the application, including the page type and URL.
-   */
-  location: AppLocation;
+	/**
+	 * The user's current location within the application, including the page type and URL.
+	 */
+	location: AppLocation;
 
-  /**
-   * Information about the current store, such as its domain, currency, and language.
-   */
-  store: Store;
+	/**
+	 * Information about the current store, such as its domain, currency, and language.
+	 */
+	store: Store;
 
-  /**
-   * Represents UI-related state, including dynamically injected components and their values.
-   */
-  ui: UI;
+	/**
+	 * Represents UI-related state, including dynamically injected components and their values.
+	 */
+	ui: UI;
 
-  /**
-   * Information about shipping, such as available options, the selected option, and custom labels.
-   * This property may be null depending on the page it is accessed from.
-   */
-  shipping: Nullable<Shipping>;
+	/**
+	 * Information about shipping, such as available options, the selected option, and custom labels.
+	 * This property may be null depending on the page it is accessed from.
+	 */
+	shipping: Nullable<Shipping>;
 
-  /**
-   * Details about the customer, including identification, contact information, and address.
-   */
-  customer: Nullable<Customer>;
+	/**
+	 * Details about the customer, including identification, contact information, and address.
+	 */
+	customer: Nullable<Customer>;
 
-  /**
-   * Information about the payment method, including type, status, and selected option.
-   */
-  payment: Nullable<Payment>;
+	/**
+	 * Information about the payment method, including type, status, and selected option.
+	 */
+	payment: Nullable<Payment>;
 };
 
 /**
@@ -72,8 +72,8 @@ export type NubeSDKState = {
  * @param event - The event that was triggered.
  */
 export type NubeSDKListener = (
-  state: Readonly<NubeSDKState>,
-  event: NubeSDKListenableEvent
+	state: Readonly<NubeSDKState>,
+	event: NubeSDKListenableEvent,
 ) => void;
 
 /**
@@ -84,8 +84,8 @@ export type NubeSDKListener = (
  * @param payload - The payload of the event.
  */
 export type NubeSDKListenerWithStateAndPayload = (
-  state: Readonly<NubeSDKState> & { payload?: Record<string, unknown> },
-  event: SuccessEvents
+	state: Readonly<NubeSDKState> & { payload?: Record<string, unknown> },
+	event: SuccessEvents,
 ) => void;
 
 /**
@@ -94,9 +94,9 @@ export type NubeSDKListenerWithStateAndPayload = (
  * @type {EventListenerMap}
  */
 type EventListenerMap = {
-  [K in SuccessEvents]: NubeSDKListenerWithStateAndPayload;
+	[K in SuccessEvents]: NubeSDKListenerWithStateAndPayload;
 } & {
-  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
+	[K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
 };
 
 /**
@@ -107,7 +107,7 @@ type EventListenerMap = {
  * @returns A partial update of the SDK state.
  */
 export type NubeSDKStateModifier = (
-  state: Readonly<NubeSDKState>
+	state: Readonly<NubeSDKState>,
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -117,7 +117,7 @@ export type NubeSDKStateModifier = (
  * @returns A partial update of the SDK state.
  */
 type NubeSDKStateModifierWithPayload = (
-  state: Readonly<NubeSDKState> & { payload?: Record<string, unknown> }
+	state: Readonly<NubeSDKState> & { payload?: Record<string, unknown> },
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -126,11 +126,11 @@ type NubeSDKStateModifierWithPayload = (
  * @type {NubeSDKStateModifierMap}
  */
 type NubeSDKStateModifierMap = {
-  // Eventos :success recebem o listener com payload
-  [K in SuccessEvents]: NubeSDKStateModifierWithPayload;
+	// Eventos :success recebem o listener com payload
+	[K in SuccessEvents]: NubeSDKStateModifierWithPayload;
 } & {
-  // Todos os outros eventos recebem o listener padrão
-  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
+	// Todos os outros eventos recebem o listener padrão
+	[K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
 };
 
 /**
@@ -139,74 +139,74 @@ type NubeSDKStateModifierMap = {
  */
 
 export type NubeSDK = {
-  /**
-   * Registers an event listener.
-   *
-   * @param event - The event type to listen for.
-   * @param listener - The function to execute when the event occurs.
-   */
-  on<T extends NubeSDKListenableEvent>(
-    event: T,
-    listener: EventListenerMap[T]
-  ): void;
+	/**
+	 * Registers an event listener.
+	 *
+	 * @param event - The event type to listen for.
+	 * @param listener - The function to execute when the event occurs.
+	 */
+	on<T extends NubeSDKListenableEvent>(
+		event: T,
+		listener: EventListenerMap[T],
+	): void;
 
-  /**
-   * Removes a registered event listener.
-   *
-   * @param event - The event type to stop listening for.
-   * @param listener - The function that was previously registered.
-   */
-  off<T extends NubeSDKListenableEvent>(
-    event: T,
-    listener: EventListenerMap[T]
-  ): void;
+	/**
+	 * Removes a registered event listener.
+	 *
+	 * @param event - The event type to stop listening for.
+	 * @param listener - The function that was previously registered.
+	 */
+	off<T extends NubeSDKListenableEvent>(
+		event: T,
+		listener: EventListenerMap[T],
+	): void;
 
-  /**
-   * Sends an event to the SDK, optionally modifying the state.
-   *
-   * @param event - The event type to send.
-   * @param modifier - An optional function to modify the SDK state.
-   */
-  send<T extends NubeSDKSendableEvent>(
-    event: T,
-    modifier?: NubeSDKStateModifierMap[T]
-  ): void;
+	/**
+	 * Sends an event to the SDK, optionally modifying the state.
+	 *
+	 * @param event - The event type to send.
+	 * @param modifier - An optional function to modify the SDK state.
+	 */
+	send<T extends NubeSDKSendableEvent>(
+		event: T,
+		modifier?: NubeSDKStateModifierMap[T],
+	): void;
 
-  /**
-   * Retrieves the current immutable state of the SDK.
-   *
-   * @returns The current state of NubeSDK.
-   */
-  getState(): Readonly<NubeSDKState>;
+	/**
+	 * Retrieves the current immutable state of the SDK.
+	 *
+	 * @returns The current state of NubeSDK.
+	 */
+	getState(): Readonly<NubeSDKState>;
 
-  /**
-   * Returns the browser APIs that can be used in the web worker.
-   *
-   * @returns The available browser APIs.
-   */
-  getBrowserAPIs(): NubeBrowserAPIs;
+	/**
+	 * Returns the browser APIs that can be used in the web worker.
+	 *
+	 * @returns The available browser APIs.
+	 */
+	getBrowserAPIs(): NubeBrowserAPIs;
 
-  /**
-   * Renders a component into a specific UI slot.
-   * The component can be either a static component or a function that receives the current state
-   * and returns a component to render.
-   *
-   * @param slot - The UI slot where the component will be rendered.
-   * @param component - The component to render, either a static component or a function that returns a component based on the current state.
-   */
-  render(
-    slot: UISlot,
-    component:
-      | NubeComponent
-      | ((state: Readonly<NubeSDKState>) => NubeComponent)
-  ): void;
+	/**
+	 * Renders a component into a specific UI slot.
+	 * The component can be either a static component or a function that receives the current state
+	 * and returns a component to render.
+	 *
+	 * @param slot - The UI slot where the component will be rendered.
+	 * @param component - The component to render, either a static component or a function that returns a component based on the current state.
+	 */
+	render(
+		slot: UISlot,
+		component:
+			| NubeComponent
+			| ((state: Readonly<NubeSDKState>) => NubeComponent),
+	): void;
 
-  /**
-   * Clears a component from a specific UI slot, removing it from the NubeSDKState.
-   *
-   * @param slot - The UI slot from which the component will be cleared.
-   */
-  clearSlot(slot: UISlot): void;
+	/**
+	 * Clears a component from a specific UI slot, removing it from the NubeSDKState.
+	 *
+	 * @param slot - The UI slot from which the component will be cleared.
+	 */
+	clearSlot(slot: UISlot): void;
 };
 
 /**
@@ -218,9 +218,9 @@ export type NubeSDK = {
 export type NubeApp = (nube: NubeSDK) => void;
 
 declare global {
-  export interface Window {
-    __APP_DATA__: Readonly<{ id: string; script: string }>;
-    __INITIAL_STATE__: Readonly<NubeSDKState>;
-    __SDK_INSTANCE__: Readonly<NubeSDK>;
-  }
+	export interface Window {
+		__APP_DATA__: Readonly<{ id: string; script: string }>;
+		__INITIAL_STATE__: Readonly<NubeSDKState>;
+		__SDK_INSTANCE__: Readonly<NubeSDK>;
+	}
 }

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -1,18 +1,18 @@
 import type { NubeBrowserAPIs } from "./browser";
 import type { NubeComponent, UI } from "./components";
 import type {
-  AppConfig,
-  AppLocation,
-  Cart,
-  Customer,
-  Payment,
-  Shipping,
-  Store,
+	AppConfig,
+	AppLocation,
+	Cart,
+	Customer,
+	Payment,
+	Shipping,
+	Store,
 } from "./domain";
 import type {
-  NubeSDKListenableEvent,
-  NubeSDKSendableEvent,
-  SuccessEvents,
+	NubeSDKListenableEvent,
+	NubeSDKSendableEvent,
+	SuccessEvents,
 } from "./events";
 
 import type { UISlot } from "./slots";
@@ -23,46 +23,46 @@ import type { DeepPartial, Nullable } from "./utility";
  * This state is immutable and contains all relevant application data.
  */
 export type NubeSDKState = {
-  /**
-   * The current cart state, containing products, pricing, and validation status.
-   */
-  cart: Cart;
+	/**
+	 * The current cart state, containing products, pricing, and validation status.
+	 */
+	cart: Cart;
 
-  /**
-   * Application-wide configuration settings, including cart validation rules.
-   */
-  config: AppConfig;
+	/**
+	 * Application-wide configuration settings, including cart validation rules.
+	 */
+	config: AppConfig;
 
-  /**
-   * The user's current location within the application, including the page type and URL.
-   */
-  location: AppLocation;
+	/**
+	 * The user's current location within the application, including the page type and URL.
+	 */
+	location: AppLocation;
 
-  /**
-   * Information about the current store, such as its domain, currency, and language.
-   */
-  store: Store;
+	/**
+	 * Information about the current store, such as its domain, currency, and language.
+	 */
+	store: Store;
 
-  /**
-   * Represents UI-related state, including dynamically injected components and their values.
-   */
-  ui: UI;
+	/**
+	 * Represents UI-related state, including dynamically injected components and their values.
+	 */
+	ui: UI;
 
-  /**
-   * Information about shipping, such as available options, the selected option, and custom labels.
-   * This property may be null depending on the page it is accessed from.
-   */
-  shipping: Nullable<Shipping>;
+	/**
+	 * Information about shipping, such as available options, the selected option, and custom labels.
+	 * This property may be null depending on the page it is accessed from.
+	 */
+	shipping: Nullable<Shipping>;
 
-  /**
-   * Details about the customer, including identification, contact information, and address.
-   */
-  customer: Nullable<Customer>;
+	/**
+	 * Details about the customer, including identification, contact information, and address.
+	 */
+	customer: Nullable<Customer>;
 
-  /**
-   * Information about the payment method, including type, status, and selected option.
-   */
-  payment: Nullable<Payment>;
+	/**
+	 * Information about the payment method, including type, status, and selected option.
+	 */
+	payment: Nullable<Payment>;
 };
 
 /*
@@ -77,8 +77,8 @@ type OptionalEventPayload = { payload?: Record<string, unknown> };
  * @param event - The event that was triggered.
  */
 export type NubeSDKListener = (
-  state: Readonly<NubeSDKState>,
-  event: NubeSDKListenableEvent
+	state: Readonly<NubeSDKState>,
+	event: NubeSDKListenableEvent,
 ) => void;
 
 /**
@@ -89,8 +89,8 @@ export type NubeSDKListener = (
 
  */
 export type NubeSDKListenerWithPayload = (
-  state: Readonly<NubeSDKState> & OptionalEventPayload,
-  event: SuccessEvents
+	state: Readonly<NubeSDKState> & OptionalEventPayload,
+	event: SuccessEvents,
 ) => void;
 
 /**
@@ -99,9 +99,9 @@ export type NubeSDKListenerWithPayload = (
  * @type {EventListenerMap}
  */
 type EventListenerMap = {
-  [K in SuccessEvents]: NubeSDKListenerWithPayload;
+	[K in SuccessEvents]: NubeSDKListenerWithPayload;
 } & {
-  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
+	[K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
 };
 
 /**
@@ -112,7 +112,7 @@ type EventListenerMap = {
  * @returns A partial update of the SDK state.
  */
 export type NubeSDKStateModifier = (
-  state: Readonly<NubeSDKState>
+	state: Readonly<NubeSDKState>,
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -122,7 +122,7 @@ export type NubeSDKStateModifier = (
  * @returns A partial update of the SDK state.
  */
 type NubeSDKStateModifierWithPayload = (
-  state: Readonly<NubeSDKState> & OptionalEventPayload
+	state: Readonly<NubeSDKState> & OptionalEventPayload,
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -131,11 +131,11 @@ type NubeSDKStateModifierWithPayload = (
  * @type {NubeSDKStateModifierMap}
  */
 type NubeSDKStateModifierMap = {
-  // Eventos :success recebem o listener com payload
-  [K in SuccessEvents]: NubeSDKStateModifierWithPayload;
+	// Eventos :success recebem o listener com payload
+	[K in SuccessEvents]: NubeSDKStateModifierWithPayload;
 } & {
-  // Todos os outros eventos recebem o listener padrão
-  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
+	// Todos os outros eventos recebem o listener padrão
+	[K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
 };
 
 /**
@@ -144,74 +144,74 @@ type NubeSDKStateModifierMap = {
  */
 
 export type NubeSDK = {
-  /**
-   * Registers an event listener.
-   *
-   * @param event - The event type to listen for.
-   * @param listener - The function to execute when the event occurs.
-   */
-  on<T extends NubeSDKListenableEvent>(
-    event: T,
-    listener: EventListenerMap[T]
-  ): void;
+	/**
+	 * Registers an event listener.
+	 *
+	 * @param event - The event type to listen for.
+	 * @param listener - The function to execute when the event occurs.
+	 */
+	on<T extends NubeSDKListenableEvent>(
+		event: T,
+		listener: EventListenerMap[T],
+	): void;
 
-  /**
-   * Removes a registered event listener.
-   *
-   * @param event - The event type to stop listening for.
-   * @param listener - The function that was previously registered.
-   */
-  off<T extends NubeSDKListenableEvent>(
-    event: T,
-    listener: EventListenerMap[T]
-  ): void;
+	/**
+	 * Removes a registered event listener.
+	 *
+	 * @param event - The event type to stop listening for.
+	 * @param listener - The function that was previously registered.
+	 */
+	off<T extends NubeSDKListenableEvent>(
+		event: T,
+		listener: EventListenerMap[T],
+	): void;
 
-  /**
-   * Sends an event to the SDK, optionally modifying the state.
-   *
-   * @param event - The event type to send.
-   * @param modifier - An optional function to modify the SDK state.
-   */
-  send<T extends NubeSDKSendableEvent>(
-    event: T,
-    modifier?: NubeSDKStateModifierMap[T]
-  ): void;
+	/**
+	 * Sends an event to the SDK, optionally modifying the state.
+	 *
+	 * @param event - The event type to send.
+	 * @param modifier - An optional function to modify the SDK state.
+	 */
+	send<T extends NubeSDKSendableEvent>(
+		event: T,
+		modifier?: NubeSDKStateModifierMap[T],
+	): void;
 
-  /**
-   * Retrieves the current immutable state of the SDK.
-   *
-   * @returns The current state of NubeSDK.
-   */
-  getState(): Readonly<NubeSDKState>;
+	/**
+	 * Retrieves the current immutable state of the SDK.
+	 *
+	 * @returns The current state of NubeSDK.
+	 */
+	getState(): Readonly<NubeSDKState>;
 
-  /**
-   * Returns the browser APIs that can be used in the web worker.
-   *
-   * @returns The available browser APIs.
-   */
-  getBrowserAPIs(): NubeBrowserAPIs;
+	/**
+	 * Returns the browser APIs that can be used in the web worker.
+	 *
+	 * @returns The available browser APIs.
+	 */
+	getBrowserAPIs(): NubeBrowserAPIs;
 
-  /**
-   * Renders a component into a specific UI slot.
-   * The component can be either a static component or a function that receives the current state
-   * and returns a component to render.
-   *
-   * @param slot - The UI slot where the component will be rendered.
-   * @param component - The component to render, either a static component or a function that returns a component based on the current state.
-   */
-  render(
-    slot: UISlot,
-    component:
-      | NubeComponent
-      | ((state: Readonly<NubeSDKState>) => NubeComponent)
-  ): void;
+	/**
+	 * Renders a component into a specific UI slot.
+	 * The component can be either a static component or a function that receives the current state
+	 * and returns a component to render.
+	 *
+	 * @param slot - The UI slot where the component will be rendered.
+	 * @param component - The component to render, either a static component or a function that returns a component based on the current state.
+	 */
+	render(
+		slot: UISlot,
+		component:
+			| NubeComponent
+			| ((state: Readonly<NubeSDKState>) => NubeComponent),
+	): void;
 
-  /**
-   * Clears a component from a specific UI slot, removing it from the NubeSDKState.
-   *
-   * @param slot - The UI slot from which the component will be cleared.
-   */
-  clearSlot(slot: UISlot): void;
+	/**
+	 * Clears a component from a specific UI slot, removing it from the NubeSDKState.
+	 *
+	 * @param slot - The UI slot from which the component will be cleared.
+	 */
+	clearSlot(slot: UISlot): void;
 };
 
 /**
@@ -223,9 +223,9 @@ export type NubeSDK = {
 export type NubeApp = (nube: NubeSDK) => void;
 
 declare global {
-  export interface Window {
-    __APP_DATA__: Readonly<{ id: string; script: string }>;
-    __INITIAL_STATE__: Readonly<NubeSDKState>;
-    __SDK_INSTANCE__: Readonly<NubeSDK>;
-  }
+	export interface Window {
+		__APP_DATA__: Readonly<{ id: string; script: string }>;
+		__INITIAL_STATE__: Readonly<NubeSDKState>;
+		__SDK_INSTANCE__: Readonly<NubeSDK>;
+	}
 }

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -1,18 +1,18 @@
 import type { NubeBrowserAPIs } from "./browser";
 import type { NubeComponent, UI } from "./components";
 import type {
-	AppConfig,
-	AppLocation,
-	Cart,
-	Customer,
-	Payment,
-	Shipping,
-	Store,
+  AppConfig,
+  AppLocation,
+  Cart,
+  Customer,
+  Payment,
+  Shipping,
+  Store,
 } from "./domain";
 import type {
-	NubeSDKListenableEvent,
-	NubeSDKSendableEvent,
-	SuccessEvents,
+  NubeSDKListenableEvent,
+  NubeSDKSendableEvent,
+  SuccessEvents,
 } from "./events";
 
 import type { UISlot } from "./slots";
@@ -23,47 +23,52 @@ import type { DeepPartial, Nullable } from "./utility";
  * This state is immutable and contains all relevant application data.
  */
 export type NubeSDKState = {
-	/**
-	 * The current cart state, containing products, pricing, and validation status.
-	 */
-	cart: Cart;
+  /**
+   * The current cart state, containing products, pricing, and validation status.
+   */
+  cart: Cart;
 
-	/**
-	 * Application-wide configuration settings, including cart validation rules.
-	 */
-	config: AppConfig;
+  /**
+   * Application-wide configuration settings, including cart validation rules.
+   */
+  config: AppConfig;
 
-	/**
-	 * The user's current location within the application, including the page type and URL.
-	 */
-	location: AppLocation;
+  /**
+   * The user's current location within the application, including the page type and URL.
+   */
+  location: AppLocation;
 
-	/**
-	 * Information about the current store, such as its domain, currency, and language.
-	 */
-	store: Store;
+  /**
+   * Information about the current store, such as its domain, currency, and language.
+   */
+  store: Store;
 
-	/**
-	 * Represents UI-related state, including dynamically injected components and their values.
-	 */
-	ui: UI;
+  /**
+   * Represents UI-related state, including dynamically injected components and their values.
+   */
+  ui: UI;
 
-	/**
-	 * Information about shipping, such as available options, the selected option, and custom labels.
-	 * This property may be null depending on the page it is accessed from.
-	 */
-	shipping: Nullable<Shipping>;
+  /**
+   * Information about shipping, such as available options, the selected option, and custom labels.
+   * This property may be null depending on the page it is accessed from.
+   */
+  shipping: Nullable<Shipping>;
 
-	/**
-	 * Details about the customer, including identification, contact information, and address.
-	 */
-	customer: Nullable<Customer>;
+  /**
+   * Details about the customer, including identification, contact information, and address.
+   */
+  customer: Nullable<Customer>;
 
-	/**
-	 * Information about the payment method, including type, status, and selected option.
-	 */
-	payment: Nullable<Payment>;
+  /**
+   * Information about the payment method, including type, status, and selected option.
+   */
+  payment: Nullable<Payment>;
 };
+
+/*
+ * Represents an optional event payload.
+ */
+type OptionalEventPayload = { payload?: Record<string, unknown> };
 
 /**
  * Represents a listener function that responds to SDK events.
@@ -72,8 +77,8 @@ export type NubeSDKState = {
  * @param event - The event that was triggered.
  */
 export type NubeSDKListener = (
-	state: Readonly<NubeSDKState>,
-	event: NubeSDKListenableEvent,
+  state: Readonly<NubeSDKState>,
+  event: NubeSDKListenableEvent
 ) => void;
 
 /**
@@ -81,11 +86,11 @@ export type NubeSDKListener = (
  *
  * @param state - The current immutable state of the SDK.
  * @param event - The event that was triggered.
- * @param payload - The payload of the event.
+
  */
-export type NubeSDKListenerWithStateAndPayload = (
-	state: Readonly<NubeSDKState> & { payload?: Record<string, unknown> },
-	event: SuccessEvents,
+export type NubeSDKListenerWithPayload = (
+  state: Readonly<NubeSDKState> & OptionalEventPayload,
+  event: SuccessEvents
 ) => void;
 
 /**
@@ -94,9 +99,9 @@ export type NubeSDKListenerWithStateAndPayload = (
  * @type {EventListenerMap}
  */
 type EventListenerMap = {
-	[K in SuccessEvents]: NubeSDKListenerWithStateAndPayload;
+  [K in SuccessEvents]: NubeSDKListenerWithPayload;
 } & {
-	[K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
+  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
 };
 
 /**
@@ -107,7 +112,7 @@ type EventListenerMap = {
  * @returns A partial update of the SDK state.
  */
 export type NubeSDKStateModifier = (
-	state: Readonly<NubeSDKState>,
+  state: Readonly<NubeSDKState>
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -117,7 +122,7 @@ export type NubeSDKStateModifier = (
  * @returns A partial update of the SDK state.
  */
 type NubeSDKStateModifierWithPayload = (
-	state: Readonly<NubeSDKState> & { payload?: Record<string, unknown> },
+  state: Readonly<NubeSDKState> & OptionalEventPayload
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -126,11 +131,11 @@ type NubeSDKStateModifierWithPayload = (
  * @type {NubeSDKStateModifierMap}
  */
 type NubeSDKStateModifierMap = {
-	// Eventos :success recebem o listener com payload
-	[K in SuccessEvents]: NubeSDKStateModifierWithPayload;
+  // Eventos :success recebem o listener com payload
+  [K in SuccessEvents]: NubeSDKStateModifierWithPayload;
 } & {
-	// Todos os outros eventos recebem o listener padrão
-	[K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
+  // Todos os outros eventos recebem o listener padrão
+  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
 };
 
 /**
@@ -139,74 +144,74 @@ type NubeSDKStateModifierMap = {
  */
 
 export type NubeSDK = {
-	/**
-	 * Registers an event listener.
-	 *
-	 * @param event - The event type to listen for.
-	 * @param listener - The function to execute when the event occurs.
-	 */
-	on<T extends NubeSDKListenableEvent>(
-		event: T,
-		listener: EventListenerMap[T],
-	): void;
+  /**
+   * Registers an event listener.
+   *
+   * @param event - The event type to listen for.
+   * @param listener - The function to execute when the event occurs.
+   */
+  on<T extends NubeSDKListenableEvent>(
+    event: T,
+    listener: EventListenerMap[T]
+  ): void;
 
-	/**
-	 * Removes a registered event listener.
-	 *
-	 * @param event - The event type to stop listening for.
-	 * @param listener - The function that was previously registered.
-	 */
-	off<T extends NubeSDKListenableEvent>(
-		event: T,
-		listener: EventListenerMap[T],
-	): void;
+  /**
+   * Removes a registered event listener.
+   *
+   * @param event - The event type to stop listening for.
+   * @param listener - The function that was previously registered.
+   */
+  off<T extends NubeSDKListenableEvent>(
+    event: T,
+    listener: EventListenerMap[T]
+  ): void;
 
-	/**
-	 * Sends an event to the SDK, optionally modifying the state.
-	 *
-	 * @param event - The event type to send.
-	 * @param modifier - An optional function to modify the SDK state.
-	 */
-	send<T extends NubeSDKSendableEvent>(
-		event: T,
-		modifier?: NubeSDKStateModifierMap[T],
-	): void;
+  /**
+   * Sends an event to the SDK, optionally modifying the state.
+   *
+   * @param event - The event type to send.
+   * @param modifier - An optional function to modify the SDK state.
+   */
+  send<T extends NubeSDKSendableEvent>(
+    event: T,
+    modifier?: NubeSDKStateModifierMap[T]
+  ): void;
 
-	/**
-	 * Retrieves the current immutable state of the SDK.
-	 *
-	 * @returns The current state of NubeSDK.
-	 */
-	getState(): Readonly<NubeSDKState>;
+  /**
+   * Retrieves the current immutable state of the SDK.
+   *
+   * @returns The current state of NubeSDK.
+   */
+  getState(): Readonly<NubeSDKState>;
 
-	/**
-	 * Returns the browser APIs that can be used in the web worker.
-	 *
-	 * @returns The available browser APIs.
-	 */
-	getBrowserAPIs(): NubeBrowserAPIs;
+  /**
+   * Returns the browser APIs that can be used in the web worker.
+   *
+   * @returns The available browser APIs.
+   */
+  getBrowserAPIs(): NubeBrowserAPIs;
 
-	/**
-	 * Renders a component into a specific UI slot.
-	 * The component can be either a static component or a function that receives the current state
-	 * and returns a component to render.
-	 *
-	 * @param slot - The UI slot where the component will be rendered.
-	 * @param component - The component to render, either a static component or a function that returns a component based on the current state.
-	 */
-	render(
-		slot: UISlot,
-		component:
-			| NubeComponent
-			| ((state: Readonly<NubeSDKState>) => NubeComponent),
-	): void;
+  /**
+   * Renders a component into a specific UI slot.
+   * The component can be either a static component or a function that receives the current state
+   * and returns a component to render.
+   *
+   * @param slot - The UI slot where the component will be rendered.
+   * @param component - The component to render, either a static component or a function that returns a component based on the current state.
+   */
+  render(
+    slot: UISlot,
+    component:
+      | NubeComponent
+      | ((state: Readonly<NubeSDKState>) => NubeComponent)
+  ): void;
 
-	/**
-	 * Clears a component from a specific UI slot, removing it from the NubeSDKState.
-	 *
-	 * @param slot - The UI slot from which the component will be cleared.
-	 */
-	clearSlot(slot: UISlot): void;
+  /**
+   * Clears a component from a specific UI slot, removing it from the NubeSDKState.
+   *
+   * @param slot - The UI slot from which the component will be cleared.
+   */
+  clearSlot(slot: UISlot): void;
 };
 
 /**
@@ -218,9 +223,9 @@ export type NubeSDK = {
 export type NubeApp = (nube: NubeSDK) => void;
 
 declare global {
-	export interface Window {
-		__APP_DATA__: Readonly<{ id: string; script: string }>;
-		__INITIAL_STATE__: Readonly<NubeSDKState>;
-		__SDK_INSTANCE__: Readonly<NubeSDK>;
-	}
+  export interface Window {
+    __APP_DATA__: Readonly<{ id: string; script: string }>;
+    __INITIAL_STATE__: Readonly<NubeSDKState>;
+    __SDK_INSTANCE__: Readonly<NubeSDK>;
+  }
 }

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -49,7 +49,7 @@ export type NubeSDKState = {
   ui: UI;
 
   /**
-   * Informaion about shipping, such as avaliable options, selected option and custom labels.
+   * Information about shipping, such as available options, the selected option, and custom labels.
    * This property may be null depending on the page it is accessed from.
    */
   shipping: Nullable<Shipping>;

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -113,12 +113,12 @@ export type NubeSDKStateModifier = (
 /**
  * Represents a function that modifies the SDK state with a payload.
  *
- * @param state - The current immutable state of the SDK.
+ * @param state - The current immutable state of the SDK. The event payload is available on state.payload.
  * @returns A partial update of the SDK state.
  */
 type NubeSDKStateModifierWithPayload = (
   state: Readonly<NubeSDKState> & { payload?: Record<string, unknown> }
-) => DeepPartial<NubeSDKState & { payload?: Record<string, unknown> }>;
+) => DeepPartial<NubeSDKState>;
 
 /**
  * Maps the events to the appropriate state modifier type.
@@ -156,7 +156,10 @@ export type NubeSDK = {
    * @param event - The event type to stop listening for.
    * @param listener - The function that was previously registered.
    */
-  off(event: NubeSDKListenableEvent, listener: NubeSDKListener): void;
+  off<T extends NubeSDKListenableEvent>(
+    event: T,
+    listener: EventListenerMap[T]
+  ): void;
 
   /**
    * Sends an event to the SDK, optionally modifying the state.

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -73,7 +73,7 @@ export type NubeSDKState = {
  */
 export type NubeSDKListener = (
   state: Readonly<NubeSDKState>,
-  event: NubeSDKSendableEvent
+  event: NubeSDKListenableEvent
 ) => void;
 
 /**
@@ -85,7 +85,7 @@ export type NubeSDKListener = (
  */
 export type NubeSDKListenerWithStateAndPayload = (
   state: Readonly<NubeSDKState> & { payload?: Record<string, unknown> },
-  event: NubeSDKSendableEvent
+  event: SuccessEvents
 ) => void;
 
 /**
@@ -94,10 +94,8 @@ export type NubeSDKListenerWithStateAndPayload = (
  * @type {EventListenerMap}
  */
 type EventListenerMap = {
-  // Eventos :success recebem o listener com payload
   [K in SuccessEvents]: NubeSDKListenerWithStateAndPayload;
 } & {
-  // Todos os outros eventos recebem o listener padrão
   [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
 };
 


### PR DESCRIPTION
This pull request introduces improvements to the NubeSDK type definitions, focusing on better event handling and listener typing. The main changes include **distinguishing between generic events and those ending with `:success`**, allowing for more precise typing of listeners and state modifiers, and refactoring the main SDK interface to leverage these improvements.

**Event Handling Enhancements:**

* Added the `SuccessEvents` type to represent events ending with `:success`, enabling more granular event handling.
* Introduced `NubeSDKListenerWithPayload` and `NubeSDKStateModifierWithPayload` types to handle events that include payloads, and mapped events to their appropriate listener and modifier types via `EventListenerMap` and `NubeSDKStateModifierMap`. [[1]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81R68-R72) [[2]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L71-R106) [[3]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L82-R178)

**SDK Interface Refactoring:**

* Updated the main `NubeSDK` type so that the `on`, `off`, and `send` methods use the new event-to-listener and event-to-modifier mappings, providing better type safety and clarity.

**General Improvements:**

* Improved documentation and fixed minor typos in comments, such as correcting the description for the `shipping` property in `NubeSDKState`.
* Bumped the package version to `0.21.0` in `package.json` to reflect these breaking type changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced event handling with per-event type safety.
  - Success events can now provide an optional payload to listeners via the state object.
  - on/off/send APIs are now generic, enabling accurate listener and modifier typing per event.
  - Broader listener compatibility: listeners receive all listenable events (not just sendable ones).

- Chores
  - Version bumped to 0.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->