### PR TITLE
feat(types): Allow key property in all components

### DIFF
--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-jsx",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Library for building JSX interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jsx/src/jsx-dev-runtime.ts
+++ b/packages/jsx/src/jsx-dev-runtime.ts
@@ -20,7 +20,7 @@ export type { JSX };
 export function jsxDEV(
 	type: FunctionComponent | undefined,
 	props: Record<string, unknown>,
-	key: string | undefined,
+	key: string | number | undefined,
 	isStaticChildren: boolean,
 	source: { fileName: string; lineNumber: number },
 	self: unknown,

--- a/packages/jsx/src/rendering.ts
+++ b/packages/jsx/src/rendering.ts
@@ -5,7 +5,7 @@ import type { FunctionComponent } from "./types";
 export function renderJSX(
 	tag: FunctionComponent | undefined,
 	props: Record<string, unknown>,
-	_key?: string,
+	key?: string | number,
 ): JSX.Element {
 	// Fragment
 	if (tag === undefined) {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.21.0",
+	"version": "0.22.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -783,6 +783,7 @@ export type NubeComponentId = string;
  */
 export type NubeComponentProps = {
 	id?: NubeComponentId;
+	key?: string | number;
 	// DON'T USE THIS, USED INTERNALLY BY THE SDK, ANY VALUE PASSED HERE WILL BE OVERWRITTEN
 	__internalId?: NubeComponentId;
 };


### PR DESCRIPTION
This PR add the property `key` to all component as `number` or `string`


```tsx
import { Field } from "@tiendanube/nube-sdk-jsx";

function MyComponent() {
  return (
    <>
      <Field
        key="firstname-field"
        label="First Name"
        name="firstname"
        onChange={(e) => {
          console.log(`User first name: ${e.value}`);
        }}
      />
      <Field
        key={2}
        label="Last Name"
        name="lastname"
        onChange={(e) => {
          console.log(`User last name: ${e.value}`);
        }}
      />
    </>
  );
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Components now accept an optional key prop as a string or number.
  * JSX supports numeric keys without type warnings, improving developer ergonomics.

* **Chores**
  * Bumped JSX package version to 0.10.0.
  * Bumped types package version to 0.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->