### PR TITLE
Rename payload state modifier prop to eventPayload

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.23.0",
+	"version": "0.23.1",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -24,15 +24,15 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  * @property {"shipping:select"} SHIPPING_SELECT - Used to select shipping option.
  */
 export const SENDABLE_EVENT = {
-	CART_VALIDATE: "cart:validate",
-	CART_ADD: "cart:add",
-	CART_REMOVE: "cart:remove",
-	CONFIG_SET: "config:set",
-	UI_SLOT_SET: "ui:slot:set",
-	SHIPPING_UPDATE_LABEL: "shipping:update:label",
-	COUPON_ADD: "coupon:add",
-	COUPON_REMOVE: "coupon:remove",
-	SHIPPING_SELECT: "shipping:select",
+  CART_VALIDATE: "cart:validate",
+  CART_ADD: "cart:add",
+  CART_REMOVE: "cart:remove",
+  CONFIG_SET: "config:set",
+  UI_SLOT_SET: "ui:slot:set",
+  SHIPPING_UPDATE_LABEL: "shipping:update:label",
+  COUPON_ADD: "coupon:add",
+  COUPON_REMOVE: "coupon:remove",
+  SHIPPING_SELECT: "shipping:select",
 } as const;
 
 /**
@@ -40,7 +40,7 @@ export const SENDABLE_EVENT = {
  * These events trigger specific actions within the SDK.
  */
 export type NubeSDKSendableEvent = Prettify<
-	ObjectValues<typeof SENDABLE_EVENT> | NubeSDKCustomEvent
+  ObjectValues<typeof SENDABLE_EVENT> | NubeSDKCustomEvent
 >;
 
 /**
@@ -73,34 +73,34 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
-	ALL: "*",
-	PAGE_LOADED: "page:loaded",
-	CART_UPDATE: "cart:update",
-	CART_ADD_SUCCESS: "cart:add:success",
-	CART_REMOVE_SUCCESS: "cart:remove:success",
-	CART_ADD_FAIL: "cart:add:fail",
-	CART_REMOVE_FAIL: "cart:remove:fail",
-	CHECKOUT_READY: "checkout:ready",
-	CHECKOUT_SUCCESS: "checkout:success",
-	SHIPPING_UPDATE: "shipping:update",
-	SHIPPING_SELECT_SUCCESS: "shipping:select:success",
-	SHIPPING_SELECT_FAIL: "shipping:select:fail",
-	CUSTOMER_UPDATE: "customer:update",
-	PAYMENT_UPDATE: "payment:update",
-	COUPON_ADD_SUCCESS: "coupon:add:success",
-	COUPON_REMOVE_SUCCESS: "coupon:remove:success",
-	COUPON_ADD_FAIL: "coupon:add:fail",
-	COUPON_REMOVE_FAIL: "coupon:remove:fail",
-	LOCATION_UPDATED: "location:updated",
-	...SENDABLE_EVENT,
+  ALL: "*",
+  PAGE_LOADED: "page:loaded",
+  CART_UPDATE: "cart:update",
+  CART_ADD_SUCCESS: "cart:add:success",
+  CART_REMOVE_SUCCESS: "cart:remove:success",
+  CART_ADD_FAIL: "cart:add:fail",
+  CART_REMOVE_FAIL: "cart:remove:fail",
+  CHECKOUT_READY: "checkout:ready",
+  CHECKOUT_SUCCESS: "checkout:success",
+  SHIPPING_UPDATE: "shipping:update",
+  SHIPPING_SELECT_SUCCESS: "shipping:select:success",
+  SHIPPING_SELECT_FAIL: "shipping:select:fail",
+  CUSTOMER_UPDATE: "customer:update",
+  PAYMENT_UPDATE: "payment:update",
+  COUPON_ADD_SUCCESS: "coupon:add:success",
+  COUPON_REMOVE_SUCCESS: "coupon:remove:success",
+  COUPON_ADD_FAIL: "coupon:add:fail",
+  COUPON_REMOVE_FAIL: "coupon:remove:fail",
+  LOCATION_UPDATED: "location:updated",
+  ...SENDABLE_EVENT,
 } as const;
 
 /**
  * Represents the possible events that can be listened to within NubeSDK that end with :success.
  */
-export type SuccessEvents = Extract<
-	NubeSDKListenableEvent,
-	`${string}:success`
+export type NubeSDKListenableSuccessEvent = Extract<
+  NubeSDKListenableEvent,
+  `${string}:success`
 >;
 
 /**
@@ -108,5 +108,5 @@ export type SuccessEvents = Extract<
  * These events notify the application about changes in state or actions.
  */
 export type NubeSDKListenableEvent = Prettify<
-	ObjectValues<typeof EVENT> | NubeSDKCustomEvent
+  ObjectValues<typeof EVENT> | NubeSDKCustomEvent
 >;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -24,15 +24,15 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  * @property {"shipping:select"} SHIPPING_SELECT - Used to select shipping option.
  */
 export const SENDABLE_EVENT = {
-  CART_VALIDATE: "cart:validate",
-  CART_ADD: "cart:add",
-  CART_REMOVE: "cart:remove",
-  CONFIG_SET: "config:set",
-  UI_SLOT_SET: "ui:slot:set",
-  SHIPPING_UPDATE_LABEL: "shipping:update:label",
-  COUPON_ADD: "coupon:add",
-  COUPON_REMOVE: "coupon:remove",
-  SHIPPING_SELECT: "shipping:select",
+	CART_VALIDATE: "cart:validate",
+	CART_ADD: "cart:add",
+	CART_REMOVE: "cart:remove",
+	CONFIG_SET: "config:set",
+	UI_SLOT_SET: "ui:slot:set",
+	SHIPPING_UPDATE_LABEL: "shipping:update:label",
+	COUPON_ADD: "coupon:add",
+	COUPON_REMOVE: "coupon:remove",
+	SHIPPING_SELECT: "shipping:select",
 } as const;
 
 /**
@@ -40,7 +40,7 @@ export const SENDABLE_EVENT = {
  * These events trigger specific actions within the SDK.
  */
 export type NubeSDKSendableEvent = Prettify<
-  ObjectValues<typeof SENDABLE_EVENT> | NubeSDKCustomEvent
+	ObjectValues<typeof SENDABLE_EVENT> | NubeSDKCustomEvent
 >;
 
 /**
@@ -73,34 +73,34 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
-  ALL: "*",
-  PAGE_LOADED: "page:loaded",
-  CART_UPDATE: "cart:update",
-  CART_ADD_SUCCESS: "cart:add:success",
-  CART_REMOVE_SUCCESS: "cart:remove:success",
-  CART_ADD_FAIL: "cart:add:fail",
-  CART_REMOVE_FAIL: "cart:remove:fail",
-  CHECKOUT_READY: "checkout:ready",
-  CHECKOUT_SUCCESS: "checkout:success",
-  SHIPPING_UPDATE: "shipping:update",
-  SHIPPING_SELECT_SUCCESS: "shipping:select:success",
-  SHIPPING_SELECT_FAIL: "shipping:select:fail",
-  CUSTOMER_UPDATE: "customer:update",
-  PAYMENT_UPDATE: "payment:update",
-  COUPON_ADD_SUCCESS: "coupon:add:success",
-  COUPON_REMOVE_SUCCESS: "coupon:remove:success",
-  COUPON_ADD_FAIL: "coupon:add:fail",
-  COUPON_REMOVE_FAIL: "coupon:remove:fail",
-  LOCATION_UPDATED: "location:updated",
-  ...SENDABLE_EVENT,
+	ALL: "*",
+	PAGE_LOADED: "page:loaded",
+	CART_UPDATE: "cart:update",
+	CART_ADD_SUCCESS: "cart:add:success",
+	CART_REMOVE_SUCCESS: "cart:remove:success",
+	CART_ADD_FAIL: "cart:add:fail",
+	CART_REMOVE_FAIL: "cart:remove:fail",
+	CHECKOUT_READY: "checkout:ready",
+	CHECKOUT_SUCCESS: "checkout:success",
+	SHIPPING_UPDATE: "shipping:update",
+	SHIPPING_SELECT_SUCCESS: "shipping:select:success",
+	SHIPPING_SELECT_FAIL: "shipping:select:fail",
+	CUSTOMER_UPDATE: "customer:update",
+	PAYMENT_UPDATE: "payment:update",
+	COUPON_ADD_SUCCESS: "coupon:add:success",
+	COUPON_REMOVE_SUCCESS: "coupon:remove:success",
+	COUPON_ADD_FAIL: "coupon:add:fail",
+	COUPON_REMOVE_FAIL: "coupon:remove:fail",
+	LOCATION_UPDATED: "location:updated",
+	...SENDABLE_EVENT,
 } as const;
 
 /**
  * Represents the possible events that can be listened to within NubeSDK that end with :success.
  */
 export type NubeSDKListenableSuccessEvent = Extract<
-  NubeSDKListenableEvent,
-  `${string}:success`
+	NubeSDKListenableEvent,
+	`${string}:success`
 >;
 
 /**
@@ -108,5 +108,5 @@ export type NubeSDKListenableSuccessEvent = Extract<
  * These events notify the application about changes in state or actions.
  */
 export type NubeSDKListenableEvent = Prettify<
-  ObjectValues<typeof EVENT> | NubeSDKCustomEvent
+	ObjectValues<typeof EVENT> | NubeSDKCustomEvent
 >;

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -1,18 +1,18 @@
 import type { NubeBrowserAPIs } from "./browser";
 import type { NubeComponent, UI } from "./components";
 import type {
-  AppConfig,
-  AppLocation,
-  Cart,
-  Customer,
-  Payment,
-  Shipping,
-  Store,
+	AppConfig,
+	AppLocation,
+	Cart,
+	Customer,
+	Payment,
+	Shipping,
+	Store,
 } from "./domain";
 import type {
-  NubeSDKListenableEvent,
-  NubeSDKSendableEvent,
-  NubeSDKListenableSuccessEvent,
+	NubeSDKListenableEvent,
+	NubeSDKListenableSuccessEvent,
+	NubeSDKSendableEvent,
 } from "./events";
 
 import type { UISlot } from "./slots";
@@ -23,46 +23,46 @@ import type { DeepPartial, Nullable } from "./utility";
  * This state is immutable and contains all relevant application data.
  */
 export type NubeSDKState = {
-  /**
-   * The current cart state, containing products, pricing, and validation status.
-   */
-  cart: Cart;
+	/**
+	 * The current cart state, containing products, pricing, and validation status.
+	 */
+	cart: Cart;
 
-  /**
-   * Application-wide configuration settings, including cart validation rules.
-   */
-  config: AppConfig;
+	/**
+	 * Application-wide configuration settings, including cart validation rules.
+	 */
+	config: AppConfig;
 
-  /**
-   * The user's current location within the application, including the page type and URL.
-   */
-  location: AppLocation;
+	/**
+	 * The user's current location within the application, including the page type and URL.
+	 */
+	location: AppLocation;
 
-  /**
-   * Information about the current store, such as its domain, currency, and language.
-   */
-  store: Store;
+	/**
+	 * Information about the current store, such as its domain, currency, and language.
+	 */
+	store: Store;
 
-  /**
-   * Represents UI-related state, including dynamically injected components and their values.
-   */
-  ui: UI;
+	/**
+	 * Represents UI-related state, including dynamically injected components and their values.
+	 */
+	ui: UI;
 
-  /**
-   * Information about shipping, such as available options, the selected option, and custom labels.
-   * This property may be null depending on the page it is accessed from.
-   */
-  shipping: Nullable<Shipping>;
+	/**
+	 * Information about shipping, such as available options, the selected option, and custom labels.
+	 * This property may be null depending on the page it is accessed from.
+	 */
+	shipping: Nullable<Shipping>;
 
-  /**
-   * Details about the customer, including identification, contact information, and address.
-   */
-  customer: Nullable<Customer>;
+	/**
+	 * Details about the customer, including identification, contact information, and address.
+	 */
+	customer: Nullable<Customer>;
 
-  /**
-   * Information about the payment method, including type, status, and selected option.
-   */
-  payment: Nullable<Payment>;
+	/**
+	 * Information about the payment method, including type, status, and selected option.
+	 */
+	payment: Nullable<Payment>;
 };
 
 /*
@@ -77,8 +77,8 @@ type OptionalEventPayload = { eventPayload?: Record<string, unknown> };
  * @param event - The event that was triggered.
  */
 export type NubeSDKListener = (
-  state: Readonly<NubeSDKState>,
-  event: NubeSDKListenableEvent
+	state: Readonly<NubeSDKState>,
+	event: NubeSDKListenableEvent,
 ) => void;
 
 /**
@@ -89,8 +89,8 @@ export type NubeSDKListener = (
 
  */
 export type NubeSDKListenerWithPayload = (
-  state: Readonly<NubeSDKState> & OptionalEventPayload,
-  event: NubeSDKListenableSuccessEvent
+	state: Readonly<NubeSDKState> & OptionalEventPayload,
+	event: NubeSDKListenableSuccessEvent,
 ) => void;
 
 /**
@@ -99,12 +99,12 @@ export type NubeSDKListenerWithPayload = (
  * @type {EventListenerMap}
  */
 type EventListenerMap = {
-  [K in NubeSDKListenableSuccessEvent]: NubeSDKListenerWithPayload;
+	[K in NubeSDKListenableSuccessEvent]: NubeSDKListenerWithPayload;
 } & {
-  [K in Exclude<
-    NubeSDKListenableEvent,
-    NubeSDKListenableSuccessEvent
-  >]: NubeSDKListener;
+	[K in Exclude<
+		NubeSDKListenableEvent,
+		NubeSDKListenableSuccessEvent
+	>]: NubeSDKListener;
 };
 
 /**
@@ -115,7 +115,7 @@ type EventListenerMap = {
  * @returns A partial update of the SDK state.
  */
 export type NubeSDKStateModifier = (
-  state: Readonly<NubeSDKState>
+	state: Readonly<NubeSDKState>,
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -125,7 +125,7 @@ export type NubeSDKStateModifier = (
  * @returns A partial update of the SDK state.
  */
 type NubeSDKStateModifierWithPayload = (
-  state: Readonly<NubeSDKState> & OptionalEventPayload
+	state: Readonly<NubeSDKState> & OptionalEventPayload,
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -134,14 +134,14 @@ type NubeSDKStateModifierWithPayload = (
  * @type {NubeSDKStateModifierMap}
  */
 type NubeSDKStateModifierMap = {
-  // Eventos :success recebem o listener com payload
-  [K in NubeSDKListenableSuccessEvent]: NubeSDKStateModifierWithPayload;
+	// Eventos :success recebem o listener com payload
+	[K in NubeSDKListenableSuccessEvent]: NubeSDKStateModifierWithPayload;
 } & {
-  // Todos os outros eventos recebem o listener padrão
-  [K in Exclude<
-    NubeSDKListenableEvent,
-    NubeSDKListenableSuccessEvent
-  >]: NubeSDKStateModifier;
+	// Todos os outros eventos recebem o listener padrão
+	[K in Exclude<
+		NubeSDKListenableEvent,
+		NubeSDKListenableSuccessEvent
+	>]: NubeSDKStateModifier;
 };
 
 /**
@@ -150,75 +150,75 @@ type NubeSDKStateModifierMap = {
  */
 
 export type NubeSDK = {
-  /**
-   * Registers an event listener.
-   *
-   * @param event - The event type to listen for.
-   * @param listener - The function to execute when the event occurs.
-   */
-  on<T extends NubeSDKListenableEvent>(
-    event: T,
-    listener: EventListenerMap[T]
-  ): void;
+	/**
+	 * Registers an event listener.
+	 *
+	 * @param event - The event type to listen for.
+	 * @param listener - The function to execute when the event occurs.
+	 */
+	on<T extends NubeSDKListenableEvent>(
+		event: T,
+		listener: EventListenerMap[T],
+	): void;
 
-  /**
-   * Removes a registered event listener.
-   *
-   * @param event - The event type to stop listening for.
-   * @param listener - The function that was previously registered.
-   */
-  off<T extends NubeSDKListenableEvent>(
-    event: T,
-    listener: EventListenerMap[T]
-  ): void;
+	/**
+	 * Removes a registered event listener.
+	 *
+	 * @param event - The event type to stop listening for.
+	 * @param listener - The function that was previously registered.
+	 */
+	off<T extends NubeSDKListenableEvent>(
+		event: T,
+		listener: EventListenerMap[T],
+	): void;
 
-  /**
-   * Sends an event to the SDK, optionally modifying the state.
-   *
-   * @param event - The event type to send.
-   * @param modifier - An optional function to modify the SDK state.
-   */
-  send<T extends NubeSDKSendableEvent>(
-    event: T,
-    modifier?: NubeSDKStateModifierMap[T]
-  ): void;
+	/**
+	 * Sends an event to the SDK, optionally modifying the state.
+	 *
+	 * @param event - The event type to send.
+	 * @param modifier - An optional function to modify the SDK state.
+	 */
+	send<T extends NubeSDKSendableEvent>(
+		event: T,
+		modifier?: NubeSDKStateModifierMap[T],
+	): void;
 
-  /**
-   * Retrieves the current immutable state of the SDK.
-   *
-   * @returns The current state of NubeSDK.
-   */
-  getState(): Readonly<NubeSDKState>;
+	/**
+	 * Retrieves the current immutable state of the SDK.
+	 *
+	 * @returns The current state of NubeSDK.
+	 */
+	getState(): Readonly<NubeSDKState>;
 
-  /**
-   * Returns the browser APIs that can be used in the web worker.
-   *
-   * @returns The available browser APIs.
-   */
-  getBrowserAPIs(): NubeBrowserAPIs;
+	/**
+	 * Returns the browser APIs that can be used in the web worker.
+	 *
+	 * @returns The available browser APIs.
+	 */
+	getBrowserAPIs(): NubeBrowserAPIs;
 
-  /**
-   * Renders a component into a specific UI slot.
-   * The component can be either a static component or a function that receives the current state
-   * and returns a component to render.
-   *
-   * @param slot - The UI slot where the component will be rendered.
-   * @param component - The component to render, either a static component or a function that returns a component based on the current state.
-   */
-  render(
-    slot: UISlot,
-    component:
-      | NubeComponent
-      | NubeComponent[]
-      | ((state: Readonly<NubeSDKState>) => NubeComponent | NubeComponent[])
-  ): void;
+	/**
+	 * Renders a component into a specific UI slot.
+	 * The component can be either a static component or a function that receives the current state
+	 * and returns a component to render.
+	 *
+	 * @param slot - The UI slot where the component will be rendered.
+	 * @param component - The component to render, either a static component or a function that returns a component based on the current state.
+	 */
+	render(
+		slot: UISlot,
+		component:
+			| NubeComponent
+			| NubeComponent[]
+			| ((state: Readonly<NubeSDKState>) => NubeComponent | NubeComponent[]),
+	): void;
 
-  /**
-   * Clears a component from a specific UI slot, removing it from the NubeSDKState.
-   *
-   * @param slot - The UI slot from which the component will be cleared.
-   */
-  clearSlot(slot: UISlot): void;
+	/**
+	 * Clears a component from a specific UI slot, removing it from the NubeSDKState.
+	 *
+	 * @param slot - The UI slot from which the component will be cleared.
+	 */
+	clearSlot(slot: UISlot): void;
 };
 
 /**
@@ -230,9 +230,9 @@ export type NubeSDK = {
 export type NubeApp = (nube: NubeSDK) => void;
 
 declare global {
-  export interface Window {
-    __APP_DATA__: Readonly<{ id: string; script: string }>;
-    __INITIAL_STATE__: Readonly<NubeSDKState>;
-    __SDK_INSTANCE__: Readonly<NubeSDK>;
-  }
+	export interface Window {
+		__APP_DATA__: Readonly<{ id: string; script: string }>;
+		__INITIAL_STATE__: Readonly<NubeSDKState>;
+		__SDK_INSTANCE__: Readonly<NubeSDK>;
+	}
 }

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -12,7 +12,7 @@ import type {
 import type {
   NubeSDKListenableEvent,
   NubeSDKSendableEvent,
-  SuccessEvents,
+  NubeSDKListenableSuccessEvent,
 } from "./events";
 
 import type { UISlot } from "./slots";
@@ -90,7 +90,7 @@ export type NubeSDKListener = (
  */
 export type NubeSDKListenerWithPayload = (
   state: Readonly<NubeSDKState> & OptionalEventPayload,
-  event: SuccessEvents
+  event: NubeSDKListenableSuccessEvent
 ) => void;
 
 /**
@@ -99,9 +99,12 @@ export type NubeSDKListenerWithPayload = (
  * @type {EventListenerMap}
  */
 type EventListenerMap = {
-  [K in SuccessEvents]: NubeSDKListenerWithPayload;
+  [K in NubeSDKListenableSuccessEvent]: NubeSDKListenerWithPayload;
 } & {
-  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
+  [K in Exclude<
+    NubeSDKListenableEvent,
+    NubeSDKListenableSuccessEvent
+  >]: NubeSDKListener;
 };
 
 /**
@@ -132,10 +135,13 @@ type NubeSDKStateModifierWithPayload = (
  */
 type NubeSDKStateModifierMap = {
   // Eventos :success recebem o listener com payload
-  [K in SuccessEvents]: NubeSDKStateModifierWithPayload;
+  [K in NubeSDKListenableSuccessEvent]: NubeSDKStateModifierWithPayload;
 } & {
   // Todos os outros eventos recebem o listener padrão
-  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
+  [K in Exclude<
+    NubeSDKListenableEvent,
+    NubeSDKListenableSuccessEvent
+  >]: NubeSDKStateModifier;
 };
 
 /**

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -1,18 +1,18 @@
 import type { NubeBrowserAPIs } from "./browser";
 import type { NubeComponent, UI } from "./components";
 import type {
-	AppConfig,
-	AppLocation,
-	Cart,
-	Customer,
-	Payment,
-	Shipping,
-	Store,
+  AppConfig,
+  AppLocation,
+  Cart,
+  Customer,
+  Payment,
+  Shipping,
+  Store,
 } from "./domain";
 import type {
-	NubeSDKListenableEvent,
-	NubeSDKSendableEvent,
-	SuccessEvents,
+  NubeSDKListenableEvent,
+  NubeSDKSendableEvent,
+  SuccessEvents,
 } from "./events";
 
 import type { UISlot } from "./slots";
@@ -23,52 +23,52 @@ import type { DeepPartial, Nullable } from "./utility";
  * This state is immutable and contains all relevant application data.
  */
 export type NubeSDKState = {
-	/**
-	 * The current cart state, containing products, pricing, and validation status.
-	 */
-	cart: Cart;
+  /**
+   * The current cart state, containing products, pricing, and validation status.
+   */
+  cart: Cart;
 
-	/**
-	 * Application-wide configuration settings, including cart validation rules.
-	 */
-	config: AppConfig;
+  /**
+   * Application-wide configuration settings, including cart validation rules.
+   */
+  config: AppConfig;
 
-	/**
-	 * The user's current location within the application, including the page type and URL.
-	 */
-	location: AppLocation;
+  /**
+   * The user's current location within the application, including the page type and URL.
+   */
+  location: AppLocation;
 
-	/**
-	 * Information about the current store, such as its domain, currency, and language.
-	 */
-	store: Store;
+  /**
+   * Information about the current store, such as its domain, currency, and language.
+   */
+  store: Store;
 
-	/**
-	 * Represents UI-related state, including dynamically injected components and their values.
-	 */
-	ui: UI;
+  /**
+   * Represents UI-related state, including dynamically injected components and their values.
+   */
+  ui: UI;
 
-	/**
-	 * Information about shipping, such as available options, the selected option, and custom labels.
-	 * This property may be null depending on the page it is accessed from.
-	 */
-	shipping: Nullable<Shipping>;
+  /**
+   * Information about shipping, such as available options, the selected option, and custom labels.
+   * This property may be null depending on the page it is accessed from.
+   */
+  shipping: Nullable<Shipping>;
 
-	/**
-	 * Details about the customer, including identification, contact information, and address.
-	 */
-	customer: Nullable<Customer>;
+  /**
+   * Details about the customer, including identification, contact information, and address.
+   */
+  customer: Nullable<Customer>;
 
-	/**
-	 * Information about the payment method, including type, status, and selected option.
-	 */
-	payment: Nullable<Payment>;
+  /**
+   * Information about the payment method, including type, status, and selected option.
+   */
+  payment: Nullable<Payment>;
 };
 
 /*
  * Represents an optional event payload.
  */
-type OptionalEventPayload = { payload?: Record<string, unknown> };
+type OptionalEventPayload = { eventPayload?: Record<string, unknown> };
 
 /**
  * Represents a listener function that responds to SDK events.
@@ -77,8 +77,8 @@ type OptionalEventPayload = { payload?: Record<string, unknown> };
  * @param event - The event that was triggered.
  */
 export type NubeSDKListener = (
-	state: Readonly<NubeSDKState>,
-	event: NubeSDKListenableEvent,
+  state: Readonly<NubeSDKState>,
+  event: NubeSDKListenableEvent
 ) => void;
 
 /**
@@ -89,8 +89,8 @@ export type NubeSDKListener = (
 
  */
 export type NubeSDKListenerWithPayload = (
-	state: Readonly<NubeSDKState> & OptionalEventPayload,
-	event: SuccessEvents,
+  state: Readonly<NubeSDKState> & OptionalEventPayload,
+  event: SuccessEvents
 ) => void;
 
 /**
@@ -99,9 +99,9 @@ export type NubeSDKListenerWithPayload = (
  * @type {EventListenerMap}
  */
 type EventListenerMap = {
-	[K in SuccessEvents]: NubeSDKListenerWithPayload;
+  [K in SuccessEvents]: NubeSDKListenerWithPayload;
 } & {
-	[K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
+  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKListener;
 };
 
 /**
@@ -112,7 +112,7 @@ type EventListenerMap = {
  * @returns A partial update of the SDK state.
  */
 export type NubeSDKStateModifier = (
-	state: Readonly<NubeSDKState>,
+  state: Readonly<NubeSDKState>
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -122,7 +122,7 @@ export type NubeSDKStateModifier = (
  * @returns A partial update of the SDK state.
  */
 type NubeSDKStateModifierWithPayload = (
-	state: Readonly<NubeSDKState> & OptionalEventPayload,
+  state: Readonly<NubeSDKState> & OptionalEventPayload
 ) => DeepPartial<NubeSDKState>;
 
 /**
@@ -131,11 +131,11 @@ type NubeSDKStateModifierWithPayload = (
  * @type {NubeSDKStateModifierMap}
  */
 type NubeSDKStateModifierMap = {
-	// Eventos :success recebem o listener com payload
-	[K in SuccessEvents]: NubeSDKStateModifierWithPayload;
+  // Eventos :success recebem o listener com payload
+  [K in SuccessEvents]: NubeSDKStateModifierWithPayload;
 } & {
-	// Todos os outros eventos recebem o listener padrão
-	[K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
+  // Todos os outros eventos recebem o listener padrão
+  [K in Exclude<NubeSDKListenableEvent, SuccessEvents>]: NubeSDKStateModifier;
 };
 
 /**
@@ -144,75 +144,75 @@ type NubeSDKStateModifierMap = {
  */
 
 export type NubeSDK = {
-	/**
-	 * Registers an event listener.
-	 *
-	 * @param event - The event type to listen for.
-	 * @param listener - The function to execute when the event occurs.
-	 */
-	on<T extends NubeSDKListenableEvent>(
-		event: T,
-		listener: EventListenerMap[T],
-	): void;
+  /**
+   * Registers an event listener.
+   *
+   * @param event - The event type to listen for.
+   * @param listener - The function to execute when the event occurs.
+   */
+  on<T extends NubeSDKListenableEvent>(
+    event: T,
+    listener: EventListenerMap[T]
+  ): void;
 
-	/**
-	 * Removes a registered event listener.
-	 *
-	 * @param event - The event type to stop listening for.
-	 * @param listener - The function that was previously registered.
-	 */
-	off<T extends NubeSDKListenableEvent>(
-		event: T,
-		listener: EventListenerMap[T],
-	): void;
+  /**
+   * Removes a registered event listener.
+   *
+   * @param event - The event type to stop listening for.
+   * @param listener - The function that was previously registered.
+   */
+  off<T extends NubeSDKListenableEvent>(
+    event: T,
+    listener: EventListenerMap[T]
+  ): void;
 
-	/**
-	 * Sends an event to the SDK, optionally modifying the state.
-	 *
-	 * @param event - The event type to send.
-	 * @param modifier - An optional function to modify the SDK state.
-	 */
-	send<T extends NubeSDKSendableEvent>(
-		event: T,
-		modifier?: NubeSDKStateModifierMap[T],
-	): void;
+  /**
+   * Sends an event to the SDK, optionally modifying the state.
+   *
+   * @param event - The event type to send.
+   * @param modifier - An optional function to modify the SDK state.
+   */
+  send<T extends NubeSDKSendableEvent>(
+    event: T,
+    modifier?: NubeSDKStateModifierMap[T]
+  ): void;
 
-	/**
-	 * Retrieves the current immutable state of the SDK.
-	 *
-	 * @returns The current state of NubeSDK.
-	 */
-	getState(): Readonly<NubeSDKState>;
+  /**
+   * Retrieves the current immutable state of the SDK.
+   *
+   * @returns The current state of NubeSDK.
+   */
+  getState(): Readonly<NubeSDKState>;
 
-	/**
-	 * Returns the browser APIs that can be used in the web worker.
-	 *
-	 * @returns The available browser APIs.
-	 */
-	getBrowserAPIs(): NubeBrowserAPIs;
+  /**
+   * Returns the browser APIs that can be used in the web worker.
+   *
+   * @returns The available browser APIs.
+   */
+  getBrowserAPIs(): NubeBrowserAPIs;
 
-	/**
-	 * Renders a component into a specific UI slot.
-	 * The component can be either a static component or a function that receives the current state
-	 * and returns a component to render.
-	 *
-	 * @param slot - The UI slot where the component will be rendered.
-	 * @param component - The component to render, either a static component or a function that returns a component based on the current state.
-	 */
-	render(
-		slot: UISlot,
-		component:
-			| NubeComponent
-			| NubeComponent[]
-			| ((state: Readonly<NubeSDKState>) => NubeComponent | NubeComponent[]),
-	): void;
+  /**
+   * Renders a component into a specific UI slot.
+   * The component can be either a static component or a function that receives the current state
+   * and returns a component to render.
+   *
+   * @param slot - The UI slot where the component will be rendered.
+   * @param component - The component to render, either a static component or a function that returns a component based on the current state.
+   */
+  render(
+    slot: UISlot,
+    component:
+      | NubeComponent
+      | NubeComponent[]
+      | ((state: Readonly<NubeSDKState>) => NubeComponent | NubeComponent[])
+  ): void;
 
-	/**
-	 * Clears a component from a specific UI slot, removing it from the NubeSDKState.
-	 *
-	 * @param slot - The UI slot from which the component will be cleared.
-	 */
-	clearSlot(slot: UISlot): void;
+  /**
+   * Clears a component from a specific UI slot, removing it from the NubeSDKState.
+   *
+   * @param slot - The UI slot from which the component will be cleared.
+   */
+  clearSlot(slot: UISlot): void;
 };
 
 /**
@@ -224,9 +224,9 @@ export type NubeSDK = {
 export type NubeApp = (nube: NubeSDK) => void;
 
 declare global {
-	export interface Window {
-		__APP_DATA__: Readonly<{ id: string; script: string }>;
-		__INITIAL_STATE__: Readonly<NubeSDKState>;
-		__SDK_INSTANCE__: Readonly<NubeSDK>;
-	}
+  export interface Window {
+    __APP_DATA__: Readonly<{ id: string; script: string }>;
+    __INITIAL_STATE__: Readonly<NubeSDKState>;
+    __SDK_INSTANCE__: Readonly<NubeSDK>;
+  }
 }


### PR DESCRIPTION
This pull request updates the NubeSDK types package to improve naming consistency, clarify event payload handling, and enhance type safety for event listeners and state modifiers. The changes focus on renaming types for clarity, updating the payload property name, and standardizing function signatures.

**Type renaming and event handling improvements:**

* Renamed the `SuccessEvents` type to `NubeSDKListenableSuccessEvent` for clearer and more descriptive event typing throughout the codebase. [[1]](diffhunk://#diff-ad6bc4ecb3819475b6e5e49bbc33789617d047270a1aa32a49f0ae5dbabf7749L101-R101) [[2]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L15-R15)
* Updated all references to `SuccessEvents` in listener and state modifier types (such as `EventListenerMap` and `NubeSDKStateModifierMap`) to use the new `NubeSDKListenableSuccessEvent` name, improving code clarity and maintainability. [[1]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L93-R93) [[2]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L102-R107) [[3]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L135-R144)

**Payload property and function signature standardization:**

* Changed the `OptionalEventPayload` property from `payload` to `eventPayload` to avoid ambiguity and better reflect its purpose.
* Standardized function signatures in listener and state modifier types by removing inconsistent tab indentation and ensuring parameter names and formatting are consistent. [[1]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L81-R81) [[2]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L115-R118) [[3]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L125-R128) [[4]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L155-R161) [[5]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L166-R172) [[6]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L177-R183) [[7]](diffhunk://#diff-1f4a910476691c75c2710422702d3fd0a4dda7085f52a2e16f568c35a296db81L207-R213)

**Version update:**

* Bumped the package version from `0.23.0` to `0.23.1` to reflect these type and API improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed public “success” event type across listener/state modifier maps to NubeSDKListenableSuccessEvent.
  - Optional payload property renamed from payload to eventPayload.
  - Minor type signature cleanup; no runtime behavior changes.

- Chores
  - Bumped types package version to 0.23.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->