### PR TITLE
fix(types): use LanguageKey at Store["language"]

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.23.2",
+	"version": "0.23.3",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -281,7 +281,7 @@ export type Store = {
 	currency: string;
 
 	/** Language code of the store (e.g., "en", "es"). */
-	language: string;
+	language: LanguageKey;
 };
 
 /**


### PR DESCRIPTION
This PR fix `Store` language type to match with `ProductDetails` LocalizedStrings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for store language by restricting accepted values to a predefined set ("es", "pt", "en"). This enhances autocomplete and validation during development and helps prevent invalid configurations. No runtime behavior changes.
* **Chores**
  * Bumped @tiendanube/nube-sdk-types version to 0.23.3 to include the updated typing. Users relying on other language strings may see compile-time warnings/errors and should align with the supported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->