### PR TITLE
Fix cart item properties type

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.24.2",
+	"version": "0.24.3",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -36,7 +36,7 @@ export type CartItem = {
 	sku: Nullable<string>;
 
 	/** Additional properties related to the product (structure unknown). */
-	properties: Array<unknown> | Record<string, unknown>;
+	properties: Record<string, string | number>;
 
 	/** URL of the product's page. */
 	url: string;


### PR DESCRIPTION
This pull request updates the type definitions for the NubeSDK, specifically refining the `CartItem` type and incrementing the package version. The most important changes are:

Type definition improvements:

* The `properties` field in the `CartItem` type (`packages/types/src/domain.ts`) is now strictly typed as `Record<string, string | number>`, replacing the previous, less specific `Array<unknown> | Record<string, unknown>`. This makes the structure and expected values clearer and safer for consumers.

Package maintenance:

* The package version in `packages/types/package.json` is bumped from `0.24.2` to `0.24.3` to reflect the type changes.