### PR TITLE
feat(types): add quickbuy open/close events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9744,7 +9744,7 @@
     },
     "packages/jsx": {
       "name": "@tiendanube/nube-sdk-jsx",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10133,7 +10133,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.21.0",
+      "version": "0.25.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10305,7 +10305,7 @@
     },
     "packages/ui": {
       "name": "@tiendanube/nube-sdk-ui",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.24.2",
+	"version": "0.25.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -70,6 +70,8 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {"coupon:remove:success"} COUPON_REMOVE_SUCCESS - Fired when a coupon is removed successfully.
  * @property {"coupon:remove:fail"} COUPON_REMOVE_FAIL - Fired when a coupon is removed unsuccessfully.
  * @property {"location:updated"} LOCATION_UPDATED - Fired when the location is updated.
+ * @property {"quickbuy:open"} QUICKBUY_OPEN - Fired when the quickbuy modal is opened.
+ * @property {"quickbuy:close"} QUICKBUY_CLOSE - Fired when the quickbuy modal is closed.
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
@@ -92,6 +94,8 @@ export const EVENT = {
 	COUPON_ADD_FAIL: "coupon:add:fail",
 	COUPON_REMOVE_FAIL: "coupon:remove:fail",
 	LOCATION_UPDATED: "location:updated",
+	QUICKBUY_OPEN: "quickbuy:open",
+	QUICKBUY_CLOSE: "quickbuy:close",
 	...SENDABLE_EVENT,
 } as const;
 


### PR DESCRIPTION
## 📝 Description

This PR adds two new event types to the NubeSDK event system to support QuickBuy modal interactions:

- `QUICKBUY_OPEN` - Fired when the quickbuy modal is opened
- `QUICKBUY_CLOSE` - Fired when the quickbuy modal is closed

## 💡 How to Use

```tsx
import type { NubeSDK } from "@tiendanube/nube-sdk-types";

export function App(nube: NubeSDK) {
	nube.on("quickbuy:open", ({ eventPayload }) => {
		console.log("open: ", eventPayload);
	});

	nube.on("quickbuy:close", ({ eventPayload }) => {
		console.log("close: ", eventPayload);
	});
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Quick Buy lifecycle events (open and close) to the event system for integrations to subscribe to and react to Quick Buy interactions.
- **Documentation**
  - Updated sendable events documentation to include the new Quick Buy open/close events, clarifying their availability to consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->