### PR TITLE
refactor(types,ui): move style types from ui to types package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10135,12 +10135,12 @@
       "name": "@tiendanube/nube-sdk-types",
       "version": "0.25.0",
       "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3"
+      },
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
         "typescript": "^5.6.2"
-      },
-      "peerDependencies": {
-        "@tiendanube/nube-sdk-ui": "*"
       }
     },
     "packages/types/node_modules/@biomejs/biome": {
@@ -10310,7 +10310,6 @@
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
         "@vitest/coverage-v8": "^3.1.1",
-        "csstype": "^3.1.3",
         "tsup": "^8.3.5",
         "typescript": "^5.6.2",
         "vitest": "^3.1.1"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.25.0",
+	"version": "0.26.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",
@@ -19,12 +19,12 @@
 		"url": "https://github.com/TiendaNube/nube-sdk/issues"
 	},
 	"homepage": "https://www.tiendanube.com",
+	"dependencies": {
+		"csstype": "^3.1.3"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "1.8.3",
 		"typescript": "^5.6.2"
-	},
-	"peerDependencies": {
-		"@tiendanube/nube-sdk-ui": "*"
 	},
 	"files": ["./src", "README.md", "CHANGELOG.md"],
 	"keywords": ["tiendanube", "nuvemshop", "nube-sdk", "ecommerce", "sdk"]

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -1,4 +1,4 @@
-import type { NubeComponentStyle } from "@tiendanube/nube-sdk-ui";
+import type * as CSS from "csstype";
 import type { NubeSDKState } from "./main";
 import type { UISlot } from "./slots";
 import type { Prettify } from "./utility";
@@ -37,6 +37,92 @@ export type FlexContent =
  * Defines possible alignment values for flex items.
  */
 export type FlexItems = "start" | "center" | "end" | "stretch";
+
+/**
+ * Represents the range of opacity values for theme colors.
+ */
+export type ThemeColorOpacityRange =
+	| 0
+	| 5
+	| 10
+	| 20
+	| 30
+	| 40
+	| 50
+	| 60
+	| 70
+	| 80
+	| 90;
+
+/**
+ * Represents a theme color class that can generate CSS custom properties.
+ */
+export interface ThemeColorInterface {
+	opacity(opacity: ThemeColorOpacityRange): string;
+	toValue(): string;
+	toString(): string;
+}
+
+export type ThemeColorValue = string;
+export type ThemeColorOpacityValue = string;
+
+/**
+ * Primitive CSS values that can be used in theme definitions.
+ */
+type ThemeCSSPrimitive = string | number;
+
+/**
+ * Represents values that can be used in theme-aware CSS properties.
+ */
+export type ThemeCSSValue =
+	| ThemeColorInterface
+	| ThemeColorOpacityValue
+	| ThemeCSSPrimitive;
+
+/**
+ * Maps properties that should use the Size type
+ */
+type SizePropertyKeys =
+	| "width"
+	| "height"
+	| "minWidth"
+	| "minHeight"
+	| "maxWidth"
+	| "maxHeight"
+	| "top"
+	| "right"
+	| "bottom"
+	| "left"
+	| "margin"
+	| "marginTop"
+	| "marginBottom"
+	| "marginLeft"
+	| "marginRight"
+	| "padding"
+	| "paddingTop"
+	| "paddingBottom"
+	| "paddingLeft"
+	| "paddingRight"
+	| "fontSize"
+	| "lineHeight"
+	| "borderWidth"
+	| "borderRadius";
+
+/**
+ * Applies Size only to size properties.
+ * The others remain as string | number.
+ */
+type EnhancedCSSProperties = {
+	[K in keyof CSS.Properties]?: K extends SizePropertyKeys
+		? Size | ThemeCSSValue
+		: CSS.Properties[K] | ThemeCSSValue;
+};
+
+/**
+ * Define named styles for Nube components.
+ * This type combines CSS properties with theme-aware values and Size types for layout properties.
+ */
+export type NubeComponentStyle = Partial<EnhancedCSSProperties>;
 
 /* -------------------------------------------------------------------------- */
 /*                            Box Component                                   */

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Library for building declarative interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
     "@vitest/coverage-v8": "^3.1.1",
-    "csstype": "^3.1.3",
     "tsup": "^8.3.5",
     "typescript": "^5.6.2",
     "vitest": "^3.1.1"

--- a/packages/ui/src/styles/StyleSheet.ts
+++ b/packages/ui/src/styles/StyleSheet.ts
@@ -1,51 +1,5 @@
-import type { Size } from "@tiendanube/nube-sdk-types";
-import type * as CSS from "csstype";
+import type { NubeComponentStyle } from "@tiendanube/nube-sdk-types";
 import { ThemeColor } from "./ThemeColor";
-import type { ThemeCSSValue } from "./theme";
-
-/**
- * Maps properties that should use the Size type
- */
-type SizePropertyKeys =
-	| "width"
-	| "height"
-	| "minWidth"
-	| "minHeight"
-	| "maxWidth"
-	| "maxHeight"
-	| "top"
-	| "right"
-	| "bottom"
-	| "left"
-	| "margin"
-	| "marginTop"
-	| "marginBottom"
-	| "marginLeft"
-	| "marginRight"
-	| "padding"
-	| "paddingTop"
-	| "paddingBottom"
-	| "paddingLeft"
-	| "paddingRight"
-	| "fontSize"
-	| "lineHeight"
-	| "borderWidth"
-	| "borderRadius";
-
-/**
- * Applies Size only to size properties.
- * The others remain as string | number.
- */
-type EnhancedCSSProperties = {
-	[K in keyof CSS.Properties]?: K extends SizePropertyKeys
-		? Size | ThemeCSSValue
-		: CSS.Properties[K] | ThemeCSSValue;
-};
-
-/**
- * Define named styles
- */
-export type NubeComponentStyle = Partial<EnhancedCSSProperties>;
 
 function parseValue(value: unknown): unknown {
 	if (value instanceof ThemeColor) {

--- a/packages/ui/src/styles/ThemeColor.ts
+++ b/packages/ui/src/styles/ThemeColor.ts
@@ -1,17 +1,9 @@
-export type ThemeColorOpacityRange =
-	| 0
-	| 5
-	| 10
-	| 20
-	| 30
-	| 40
-	| 50
-	| 60
-	| 70
-	| 80
-	| 90;
+import type {
+	ThemeColorInterface,
+	ThemeColorOpacityRange,
+} from "@tiendanube/nube-sdk-types";
 
-export class ThemeColor {
+export class ThemeColor implements ThemeColorInterface {
 	constructor(private readonly token: string) {}
 
 	opacity(opacity: ThemeColorOpacityRange) {

--- a/packages/ui/src/styles/theme.ts
+++ b/packages/ui/src/styles/theme.ts
@@ -1,3 +1,8 @@
+import type {
+	ThemeCSSValue,
+	ThemeColorOpacityValue,
+	ThemeColorValue,
+} from "@tiendanube/nube-sdk-types";
 import { ThemeColor } from "./ThemeColor";
 
 export const theme = {
@@ -59,12 +64,6 @@ export const theme = {
 } as const;
 
 export type Theme = typeof theme;
-export type ThemeColorValue = ReturnType<ThemeColor["toValue"]>;
-export type ThemeColorOpacityValue = ReturnType<ThemeColor["opacity"]>;
 
-type ThemeCSSPrimitive = string | number;
-
-export type ThemeCSSValue =
-	| ThemeColor
-	| ThemeColorOpacityValue
-	| ThemeCSSPrimitive;
+// Re-export types from the types package for backward compatibility
+export type { ThemeColorValue, ThemeColorOpacityValue, ThemeCSSValue };


### PR DESCRIPTION
Extract NubeComponentStyle and theme types to eliminate **`circular dependencies`**.
Move csstype dependency to types package where it's actually used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded theme-aware styling with richer CSS value support across components.
  - Standardized ThemeColor with predefined opacity levels and improved interoperability.

- Refactor
  - Consolidated styling and color types into a shared types package for consistency across modules.
  - UI package now consumes external types; runtime styling behavior remains unchanged.

- Chores
  - Version bumps: Types to 0.26.0, UI to 0.11.0.
  - Dependency updates: Added csstype to types package; removed from UI.
  - Removed a peer dependency no longer required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->