### PR TITLE
chore: bump types version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10133,7 +10133,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.28.0",
+	"version": "0.29.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.

- Chores
  - Bumped the Nube SDK Types package version to 0.29.0.
  - No changes to public-facing declarations or behavior; functionality remains the same.
  - No breaking changes or migrations required; safe to upgrade.
  - Consumers may update dependencies to stay current with the latest package release and ensure compatibility with the broader SDK ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->