### PR TITLE
chore: bump create-nube-app to v0.20.0 and update template dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9845,7 +9845,7 @@
       }
     },
     "packages/create-nube-app": {
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.10.0",

--- a/packages/create-nube-app/package.json
+++ b/packages/create-nube-app/package.json
@@ -3,7 +3,7 @@
 	"description": "Create Nube App",
 	"author": "Tiendanube / Nuvemshop",
 	"license": "MIT",
-	"version": "0.19.1",
+	"version": "0.20.0",
 	"bin": {
 		"create-nube-app": "dist/index.js"
 	},

--- a/packages/create-nube-app/templates/minimal-ui-jsx/package.json
+++ b/packages/create-nube-app/templates/minimal-ui-jsx/package.json
@@ -14,9 +14,9 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-ui": "^0.9.3",
-		"@tiendanube/nube-sdk-jsx": "^0.9.0",
-		"@tiendanube/nube-sdk-types": "^0.18.0",
+		"@tiendanube/nube-sdk-ui": "^0.12.0",
+		"@tiendanube/nube-sdk-jsx": "^0.11.0",
+		"@tiendanube/nube-sdk-types": "^0.31.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/create-nube-app/templates/minimal-ui/package.json
+++ b/packages/create-nube-app/templates/minimal-ui/package.json
@@ -14,8 +14,8 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-ui": "^0.9.3",
-		"@tiendanube/nube-sdk-types": "^0.18.0",
+		"@tiendanube/nube-sdk-ui": "^0.12.0",
+		"@tiendanube/nube-sdk-types": "^0.31.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/create-nube-app/templates/minimal/package.json
+++ b/packages/create-nube-app/templates/minimal/package.json
@@ -13,7 +13,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-types": "^0.18.0",
+		"@tiendanube/nube-sdk-types": "^0.31.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",


### PR DESCRIPTION
- Update create-nube-app version from 0.19.1 to 0.20.0
- Update @tiendanube/nube-sdk-ui to ^0.12.0 in templates
- Update @tiendanube/nube-sdk-jsx to ^0.11.0 in minimal-ui-jsx template
- Update @tiendanube/nube-sdk-types to ^0.31.0 across all templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped create-nube-app to version 0.20.0.
  - Updated template dependencies to latest Nube SDKs for improved compatibility:
    - minimal-ui-jsx: @tiendanube/nube-sdk-ui ^0.12.0, @tiendanube/nube-sdk-jsx ^0.11.0, @tiendanube/nube-sdk-types ^0.31.0.
    - minimal-ui: @tiendanube/nube-sdk-ui ^0.12.0, @tiendanube/nube-sdk-types ^0.31.0.
    - minimal: @tiendanube/nube-sdk-types ^0.31.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->