### PR TITLE
fix: update NPM publish context to NPM_TOKEN_SDK2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,18 +165,18 @@ workflows:
           filters:
             <<: *filter-prd
       - publish-types:
-          context: NPM_TOKEN_SDK
+          context: NPM_TOKEN_SDK2
           requires:
             - approval-publish-types
       - publish-ui:
-          context: NPM_TOKEN_SDK
+          context: NPM_TOKEN_SDK2
           requires:
             - approval-publish-ui
       - publish-jsx:
-          context: NPM_TOKEN_SDK
+          context: NPM_TOKEN_SDK2
           requires:
             - approval-publish-jsx
       - publish-create-nube-app:
-          context: NPM_TOKEN_SDK
+          context: NPM_TOKEN_SDK2
           requires:
             - approval-publish-create-nube-app


### PR DESCRIPTION
## Description

This pull request updates the deployment contexts used in several CircleCI publish workflows. The main change is switching from the `NPM_TOKEN_SDK` context to `NPM_TOKEN_SDK2` for publishing steps.

- **CI/CD configuration update:**
  * Updated the `context` for the `publish-types`, `publish-ui`, `publish-jsx`, and `publish-create-nube-app` jobs in `.circleci/config.yml` from `NPM_TOKEN_SDK` to `NPM_TOKEN_SDK2` to use the new NPM token context for publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration for npm package publishing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->