### PR TITLE
ci: update NPM token reference from NPM_TOKEN_SDK to NPM_TOKEN_SDK2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - run:
           name: Publish @tiendanube/nube-sdk-types
           command: |
-            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN_SDK
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN_SDK2
             npm publish --workspace packages/types --access public
 
   publish-ui:
@@ -89,7 +89,7 @@ jobs:
       - run:
           name: Publish @tiendanube/nube-sdk-ui
           command: |
-            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN_SDK
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN_SDK2
             npm run build --workspace packages/ui
             npm publish --workspace packages/ui --access public
 
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Publish @tiendanube/nube-sdk-jsx
           command: |
-            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN_SDK
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN_SDK2
             npm run build
             npm publish --workspace packages/jsx --access public
 
@@ -117,7 +117,7 @@ jobs:
       - run:
           name: Publish create-nube-app
           command: |
-            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN_SDK
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN_SDK2
             npm run build
             npm publish --workspace packages/create-nube-app --access public
 


### PR DESCRIPTION
- Updated all publish jobs to use the new NPM_TOKEN_SDK2 environment variable
- Affects publish-types, publish-ui, publish-jsx, and publish-create-nube-app jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm authentication configuration for package publishing pipeline. This ensures secure and proper deployment of packages across multiple distribution channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->