### PR TITLE
feat(types): add session to state

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.37.0",
+	"version": "0.38.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -681,3 +681,11 @@ export type Payment = {
 	status: Nullable<PaymentStatus>;
 	selected: Nullable<SelectedPayment>;
 };
+
+/**
+ * Represents the session information.
+ */
+export type Session = {
+	/** Unique identifier for the session. */
+	id: Nullable<string>;
+};

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -8,6 +8,7 @@ import type {
 	Device,
 	Order,
 	Payment,
+	Session,
 	Shipping,
 	Store,
 } from "./domain";
@@ -79,6 +80,11 @@ export type NubeSDKState = {
 	 * Optional event payload
 	 */
 	eventPayload: Nullable<Record<string, unknown>>;
+
+	/**
+	 * Information about the session, including the session ID.
+	 */
+	session: Session;
 };
 
 /*


### PR DESCRIPTION
This PR adds the `session.id` in SDK State

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session tracking support to the SDK with session identification capabilities integrated into the state management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->