### PR TITLE
feat: add iframe component support

### DIFF
--- a/packages/jsx/src/components.tsx
+++ b/packages/jsx/src/components.tsx
@@ -41,6 +41,8 @@ import type {
 	NubeComponentGProps,
 	NubeComponentIcon,
 	NubeComponentIconProps,
+	NubeComponentIframe,
+	NubeComponentIframeProps,
 	NubeComponentImage,
 	NubeComponentImageProps,
 	NubeComponentLine,
@@ -104,6 +106,7 @@ import {
 	field,
 	fragment,
 	icon,
+	iframe,
 	image,
 	link,
 	numberfield,
@@ -346,6 +349,19 @@ export function Img(props: NubeComponentImageProps): NubeComponentImage {
  */
 export function Image(props: NubeComponentImageProps): NubeComponentImage {
 	return image(props);
+}
+
+/**
+ * Creates an `Iframe` component.
+ *
+ * The `Iframe` component is used to embed external content. It supports properties such as
+ * `src`, `width`, `height`, `sandbox`, and `style`.
+ *
+ * @param props - The properties for configuring the iframe component.
+ * @returns A `NubeComponentIframe` object representing the iframe component.
+ */
+export function Iframe(props: NubeComponentIframeProps): NubeComponentIframe {
+	return iframe(props);
 }
 
 /**

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -620,6 +620,39 @@ export type NubeComponentImage = Prettify<
 >;
 
 /* -------------------------------------------------------------------------- */
+/*                             Iframe Component                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Represents the properties available for an `iframe` component.
+ * Designed for third-party content integration in e-commerce stores.
+ */
+export type NubeComponentIframeProps = Prettify<
+	NubeComponentBase & {
+		/** Third-party content URL (HTTPS only for security) */
+		src: SecurityURL;
+		/** Widget width (controlled by third-party) */
+		width?: Size;
+		/** Widget height (controlled by third-party) */
+		height?: Size;
+		/** Security sandbox restrictions (defaults to safe third-party settings) */
+		sandbox?: string;
+		/** Basic styling within platform theme constraints */
+		style?: NubeComponentStyle;
+	}
+>;
+
+/**
+ * Represents an `iframe` component, used to embed external content.
+ */
+export type NubeComponentIframe = Prettify<
+	NubeComponentBase &
+		NubeComponentIframeProps & {
+			type: "iframe";
+		}
+>;
+
+/* -------------------------------------------------------------------------- */
 /*                           Txt Component                                    */
 /* -------------------------------------------------------------------------- */
 
@@ -1767,6 +1800,7 @@ export type NubeComponent =
 	| NubeComponentNumberField
 	| NubeComponentFragment
 	| NubeComponentImage
+	| NubeComponentIframe
 	| NubeComponentText
 	| NubeComponentCheckbox
 	| NubeComponentTextarea

--- a/packages/ui/src/components/iframe.ts
+++ b/packages/ui/src/components/iframe.ts
@@ -1,0 +1,22 @@
+import type {
+	NubeComponentIframe,
+	NubeComponentIframeProps,
+} from "@tiendanube/nube-sdk-types";
+import { generateInternalId } from "./generateInternalId";
+
+/**
+ * Creates an `iframe` component.
+ *
+ * The `iframe` component is used to embed external content. It supports properties such as
+ * `src`, `width`, `height`, `sandbox`, and `style`.
+ *
+ * @param props - The properties for configuring the iframe component.
+ * @returns A `NubeComponentIframe` object representing the iframe component.
+ */
+export const iframe = (
+	props: NubeComponentIframeProps,
+): NubeComponentIframe => ({
+	type: "iframe",
+	...props,
+	__internalId: generateInternalId("iframe", props),
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@ export * from "./components/field";
 export * from "./components/number-field";
 export * from "./components/fragment";
 export * from "./components/image";
+export * from "./components/iframe";
 export * from "./components/text";
 export * from "./components/checkbox";
 export * from "./components/textarea";


### PR DESCRIPTION
## Description

This PR introduces a new Iframe component to the Nube SDK, enabling third-party content integration in e-commerce stores.

## Related PR's

- https://github.com/TiendaNube/nube-sdk-internal/pull/111

## How to use it?

```tsx
nube.render(
	"before_main_content",
	<Iframe
		key="305066603"
		src="https://www.nuvemshop.com.br/"
		width={800}
		height={400}
		sandbox="allow-scripts allow-top-navigation"
	/>,
);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Iframe component for embedding external content with support for customizable dimensions, sandbox security options, and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->