### PR TITLE
feat: add innerWidth and innerHeight to DeviceScreen type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10421,7 +10421,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.42.0",
+	"version": "0.43.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -25,6 +25,10 @@ export type DeviceScreen = {
 	orientation: DeviceScreenOrientation;
 	/** The pixel ratio of the screen. */
 	pixelRatio: number;
+	/** The width of the inner window in pixels. */
+	innerWidth: number;
+	/** The height of the inner window in pixels. */
+	innerHeight: number;
 };
 
 /**


### PR DESCRIPTION
## Add innerWidth and innerHeight to DeviceScreen type

This PR adds `innerWidth` and `innerHeight` properties to the `DeviceScreen` type to track the inner window dimensions in pixels.

### Changes
- Added `innerWidth: number` property to `DeviceScreen`
- Added `innerHeight: number` property to `DeviceScreen`
- Updated JSDoc comments for both properties

### Why
These properties allow apps to access the actual viewport dimensions, which is useful for responsive layouts and component sizing decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inner window dimension tracking to device screen metrics, enabling more detailed capture of the display environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->