### PR TITLE
feat(types): add before_cart slot to storefront

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10421,7 +10421,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.44.0",
+	"version": "0.45.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -94,6 +94,7 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"product_grid_item_image_top_left"} PRODUCT_GRID_ITEM_IMAGE_TOP_LEFT - Top left corner of product grid item images.
  * @property {"product_grid_item_image_bottom_right"} PRODUCT_GRID_ITEM_IMAGE_BOTTOM_RIGHT - Bottom right corner of product grid item images.
  * @property {"product_grid_item_image_bottom_left"} PRODUCT_GRID_ITEM_IMAGE_BOTTOM_LEFT - Bottom left corner of product grid item images.
+ * @property {"before_cart"} BEFORE_CART - Before the cart section.
  * @property {"before_start_checkout_button"} BEFORE_START_CHECKOUT_BUTTON - Before the start checkout button.
  * @property {"after_go_to_checkout"} AFTER_GO_TO_CHECKOUT - After the go to checkout button.
  * @property {"after_cart_summary"} AFTER_CART_SUMMARY - After the cart summary.
@@ -118,6 +119,7 @@ export const STOREFRONT_UI_SLOT = {
 	PRODUCT_GRID_ITEM_IMAGE_TOP_LEFT: "product_grid_item_image_top_left",
 	PRODUCT_GRID_ITEM_IMAGE_BOTTOM_RIGHT: "product_grid_item_image_bottom_right",
 	PRODUCT_GRID_ITEM_IMAGE_BOTTOM_LEFT: "product_grid_item_image_bottom_left",
+	BEFORE_CART: "before_cart",
 	BEFORE_START_CHECKOUT_BUTTON: "before_start_checkout_button",
 	AFTER_GO_TO_CHECKOUT: "after_go_to_checkout",
 	AFTER_CART_SUMMARY: "after_cart_summary",


### PR DESCRIPTION
## Description

This pull request updates the type definitions for UI slots in the NubeSDK types package, primarily by adding a new slot for customizing the checkout and storefront cart experience. It also includes a version bump for the package.

**UI Slots Update:**

* Added a new slot `BEFORE_CART` to both `CHECKOUT_UI_SLOT` and `STOREFRONT_UI_SLOT`, allowing integrations to inject content before the cart section in the checkout and storefront flows. [[1]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR97) [[2]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR122)

**Package Maintenance:**

* Bumped the package version from `0.44.0` to `0.45.0` in `package.json` to reflect the new slot addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new customizable UI slot positioned before the cart section, enabling greater control over storefront layout customization.

* **Chores**
  * Version updated to 0.45.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->