### PR TITLE
feat: add cart line item top slot to storefront ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10421,7 +10421,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"
@@ -10593,7 +10593,7 @@
     },
     "packages/ui": {
       "name": "@tiendanube/nube-sdk-ui",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.44.0",
+	"version": "0.45.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -98,6 +98,7 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_go_to_checkout"} AFTER_GO_TO_CHECKOUT - After the go to checkout button.
  * @property {"after_cart_summary"} AFTER_CART_SUMMARY - After the cart summary.
  * @property {"before_footer"} BEFORE_FOOTER - Before the footer.
+ * @property {"cart_line_item_top"} CART_LINE_ITEM_TOP - Top of the cart line item.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -122,6 +123,7 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_GO_TO_CHECKOUT: "after_go_to_checkout",
 	AFTER_CART_SUMMARY: "after_cart_summary",
 	BEFORE_FOOTER: "before_footer",
+	CART_LINE_ITEM_TOP: "cart_line_item_top",
 } as const;
 
 /**


### PR DESCRIPTION
### Description

This pull request adds a new UI slot to the `STOREFRONT_UI_SLOT` constants, allowing for more flexible placement of components at the top of cart line items in the storefront.

**Enhancements to UI slot options:**

* Added a new slot, `CART_LINE_ITEM_TOP`, to the `STOREFRONT_UI_SLOT` object and its documentation, enabling components to be rendered at the top of each cart line item. [[1]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR101) [[2]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR126)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customization slot for the top of cart line items, usable in both checkout and storefront to enable more flexible cart display customizations.
* **Chores**
  * Package version updated to v0.45.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->