### PR TITLE
feat(types): add iframe message communication support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10421,7 +10421,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.45.0",
+	"version": "0.46.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/browser.ts
+++ b/packages/types/src/browser.ts
@@ -1,3 +1,4 @@
+import type { JsonObject, NubeComponent } from "./components";
 import type { AsyncNubeStorage } from "./storage";
 
 /**
@@ -19,4 +20,11 @@ export type NubeBrowserAPIs = {
 	 * @param route The route to navigate to. Must start with '/'.
 	 */
 	navigate: (route: `/${string}`) => void;
+
+	/**
+	 * Posts a message to the iframe.
+	 * @param iframe The iframe component to post the message to.
+	 * @param message The message to post to the iframe.
+	 */
+	postMessageToIframe: (iframe: NubeComponent, message: JsonObject) => void;
 };

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -659,6 +659,21 @@ export type NubeComponentProgress = Prettify<
 /*                         Iframe Component                                  */
 /* -------------------------------------------------------------------------- */
 
+export type JsonValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JsonValue[]
+	| { [key: string]: JsonValue };
+
+export type JsonObject = { [key: string]: JsonValue };
+
+export type NubeComponentIframeEventHandler = NubeComponentEventHandler<
+	"message",
+	JsonObject
+>;
+
 /**
  * Represents the properties available for an `iframe` component.
  * Designed for third-party content integration in e-commerce stores.
@@ -675,6 +690,8 @@ export type NubeComponentIframeProps = Prettify<
 		sandbox?: string;
 		/** Basic styling within platform theme constraints */
 		style?: NubeComponentStyle;
+		/** Event handler for messages from the iframe */
+		onMessage?: NubeComponentIframeEventHandler;
 	}
 >;
 

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -1,4 +1,5 @@
 import type {
+	NubeIframeMessageEventData,
 	NubeNavigateEventData,
 	NubeStorageEvent,
 	NubeStorageEventData,
@@ -8,7 +9,8 @@ export type NubeSdkInternalEvent = NubeStorageEvent;
 
 export type NubeSdkInternalEventData =
 	| NubeStorageEventData
-	| NubeNavigateEventData;
+	| NubeNavigateEventData
+	| NubeIframeMessageEventData;
 
 export const NubeSdkInternalEventPrefix = "internal:";
 

--- a/packages/types/src/storage.ts
+++ b/packages/types/src/storage.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from "./components";
+
 export type NubeStorageEvent =
 	| "internal:storage:get"
 	| "internal:storage:get:response"
@@ -5,7 +7,8 @@ export type NubeStorageEvent =
 	| "internal:storage:set:response"
 	| "internal:storage:remove"
 	| "internal:storage:remove:response"
-	| "internal:navigate";
+	| "internal:navigate"
+	| "internal:iframe:message";
 
 export type NubeStorageId = "local-storage" | "session-storage";
 
@@ -53,6 +56,12 @@ export type NubeStorageEventData =
 
 export type NubeNavigateEventData = {
 	route: `/${string}`;
+};
+
+export type NubeIframeMessageEventData = {
+	iframeId: string;
+	message: JsonObject;
+	src?: string;
 };
 
 export interface AsyncNubeStorage {


### PR DESCRIPTION
## Description

Adds bidirectional message communication between the app and iframe components.

**Changes:**
- Add `postMessageToIframe` API method to send messages to iframe components
- Add `onMessage` event handler for iframe components to receive messages
- Add `JsonValue` type for message payload validation
- Add internal event types for iframe message communication

## Related PR's

- https://github.com/TiendaNube/nube-sdk-internal/pull/129

## Usage:

```tsx
// IFRAME -> APP
<Iframe
  src="https://myiframe.com.br"
  onMessage={(message) => {
    console.log("🚀 ~ message:", message);
  }}
/>
```

```tsx
// APP -> IFRAME
const browser = nube.getBrowserAPIs();
browser.postMessageToIframe(Component, {
  message: name,
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parent components can send JSON-serializable messages to embedded iframes.
  * Public API to post messages to iframes added.
  * Iframe components can optionally handle incoming message events via a new handler.
  * Strongly-typed JSON payload support introduced across the public API.
  * Internal event model extended to include iframe message events for integrations and tooling.

* **Chores**
  * Package version bumped to 0.46.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->