### PR TITLE
feat(types): add after_header slot

### DIFF
--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -17,6 +17,7 @@ import type { ObjectValues, Prettify } from "./utility";
  * @property {"corner_bottom_right"} CORNER_BOTTOM_RIGHT - Bottom right corner of the page.
  * @property {"before_line_items"} BEFORE_LINE_ITEMS - Before the list of items in the cart.
  * @property {"after_line_items"} AFTER_LINE_ITEMS - After the list of items in the cart.
+ * @property {"after_header"} AFTER_HEADER - After the header.
  */
 export const COMMON_UI_SLOT = {
 	BEFORE_MAIN_CONTENT: "before_main_content",
@@ -28,6 +29,7 @@ export const COMMON_UI_SLOT = {
 	CORNER_BOTTOM_RIGHT: "corner_bottom_right",
 	BEFORE_LINE_ITEMS: "before_line_items",
 	AFTER_LINE_ITEMS: "after_line_items",
+	AFTER_HEADER: "after_header",
 } as const;
 
 /**


### PR DESCRIPTION
## Description

This pull request adds a new slot identifier to the common UI slots in the type definitions. This allows components to be rendered immediately after the header in the UI.

UI slot additions:

* Added a new `AFTER_HEADER` slot to the `COMMON_UI_SLOT` object and its documentation in `slots.ts`, enabling UI extensions to target the area after the header. [[1]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR20) [[2]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR32)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new "after_header" slot, expanding customization options for content placement following the header section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->