### PR TITLE
feat: add product grid UI slots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10421,7 +10421,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.46.0",
+	"version": "0.47.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -88,10 +88,13 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"product_detail_image_top_left"} PRODUCT_DETAIL_IMAGE_TOP_LEFT - Top left corner of product detail images.
  * @property {"product_detail_image_top_right"} PRODUCT_DETAIL_IMAGE_TOP_RIGHT - Top right corner of product detail images.
  * @property {"after_product_detail_name"} AFTER_PRODUCT_DETAIL_NAME - After the product name in product detail.
+ * @property {"before_product_detail_name"} BEFORE_PRODUCT_DETAIL_NAME - Before the product name in product detail.
  * @property {"after_product_description"} AFTER_PRODUCT_DESCRIPTION - After the product description.
  * @property {"before_price_pdp"} BEFORE_PRICE_PDP - Before the price on product detail page.
  * @property {"after_price_pdp"} AFTER_PRICE_PDP - After the price on product detail page.
  * @property {"after_product_grid_item_name"} AFTER_PRODUCT_GRID_ITEM_NAME - After the product name in grid items.
+ * @property {"product_grid_before_product_detail_name"} PRODUCT_GRID_BEFORE_PRODUCT_DETAIL_NAME - Before the product detail name in product grid.
+ * @property {"product_grid_after_product_price_name"} PRODUCT_GRID_AFTER_PRODUCT_PRICE_NAME - After the product price name in product grid.
  * @property {"product_grid_item_image_top_right"} PRODUCT_GRID_ITEM_IMAGE_TOP_RIGHT - Top right corner of product grid item images.
  * @property {"product_grid_item_image_top_left"} PRODUCT_GRID_ITEM_IMAGE_TOP_LEFT - Top left corner of product grid item images.
  * @property {"product_grid_item_image_bottom_right"} PRODUCT_GRID_ITEM_IMAGE_BOTTOM_RIGHT - Bottom right corner of product grid item images.
@@ -117,6 +120,10 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_PRICE_PDP: "after_price_pdp",
 	PRODUCT_DETAIL_IMAGE_TOP_RIGHT: "product_detail_image_top_right",
 	AFTER_PRODUCT_GRID_ITEM_NAME: "after_product_grid_item_name",
+	PRODUCT_GRID_BEFORE_PRODUCT_DETAIL_NAME:
+		"product_grid_before_product_detail_name",
+	PRODUCT_GRID_AFTER_PRODUCT_PRICE_NAME:
+		"product_grid_after_product_price_name",
 	PRODUCT_GRID_ITEM_IMAGE_TOP_RIGHT: "product_grid_item_image_top_right",
 	PRODUCT_GRID_ITEM_IMAGE_TOP_LEFT: "product_grid_item_image_top_left",
 	PRODUCT_GRID_ITEM_IMAGE_BOTTOM_RIGHT: "product_grid_item_image_bottom_right",
@@ -126,6 +133,7 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_CART_SUMMARY: "after_cart_summary",
 	BEFORE_FOOTER: "before_footer",
 	CART_LINE_ITEM_TOP: "cart_line_item_top",
+	BEFORE_PRODUCT_DETAIL_NAME: "before_product_detail_name",
 } as const;
 
 /**


### PR DESCRIPTION
## Description

This PR adds new UI slots to the storefront context, expanding customization options for product grid and product detail pages.

## Changes

- Added `PRODUCT_GRID_BEFORE_PRODUCT_DETAIL_NAME` slot - allows placing components before the product detail name in product grid items
- Added `PRODUCT_GRID_AFTER_PRODUCT_PRICE_NAME` slot - allows placing components after the product price name in product grid items
- Added `BEFORE_PRODUCT_DETAIL_NAME` slot - allows placing components before the product detail name
- Added `AFTER_PRODUCT_PRICE_NAME` slot - allows placing components after the product price name

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Types compile successfully
- [x] New slots are properly exported and typed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new storefront UI customization slots to place custom content in product grids and product detail views (positions before a product's detail name, an extra pre-detail slot, and after the product price).

* **Chores**
  * Package version bumped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->