### PR TITLE
feat(types): add subtotal_without_taxes to cart.prices object

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.47.0",
+	"version": "0.48.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -251,6 +251,9 @@ export type Prices = {
 
 	/** Final total price after all discounts and shipping. */
 	total: number;
+
+	/** Subtotal before discounts and shipping, without taxes. */
+	subtotal_without_taxes: number;
 };
 
 /**


### PR DESCRIPTION
This PR adds the property `subtotal_without_taxes` to `state.cart.prices`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subtotal without taxes to pricing information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->