### PR TITLE
feat: markdown component

### DIFF
--- a/packages/jsx/src/components.tsx
+++ b/packages/jsx/src/components.tsx
@@ -51,6 +51,8 @@ import type {
 	NubeComponentLinearGradientProps,
 	NubeComponentLink,
 	NubeComponentLinkProps,
+	NubeComponentMarkdown,
+	NubeComponentMarkdownProps,
 	NubeComponentMask,
 	NubeComponentMaskProps,
 	NubeComponentNumberField,
@@ -113,6 +115,7 @@ import {
 	iframe,
 	image,
 	link,
+	markdown,
 	numberfield,
 	progress,
 	row,
@@ -413,6 +416,21 @@ export function SideScroll(
 	props: NubeComponentSideScrollProps,
 ): NubeComponentSideScroll {
 	return sideScroll(props);
+}
+
+/**
+ * Creates a `Markdown` component.
+ *
+ * The `Markdown` component is used to render markdown content.
+ * It supports properties such as `content` for the markdown string.
+ *
+ * @param props - The properties for configuring the markdown component.
+ * @returns A `NubeComponentMarkdown` object representing the markdown component.
+ */
+export function Markdown(
+	props: NubeComponentMarkdownProps,
+): NubeComponentMarkdown {
+	return markdown(props);
 }
 
 /**

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -1838,6 +1838,29 @@ export type NubeComponentSideScroll = Prettify<
 >;
 
 /* -------------------------------------------------------------------------- */
+/*                           Markdown Component                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Represents the properties available for a `markdown` component.
+ */
+export type NubeComponentMarkdownProps = Prettify<
+	NubeComponentBase & {
+		content: string;
+	}
+>;
+
+/**
+ * Represents a `markdown` component, used for rendering markdown content.
+ */
+export type NubeComponentMarkdown = Prettify<
+	NubeComponentBase &
+		NubeComponentMarkdownProps & {
+			type: "markdown";
+		}
+>;
+
+/* -------------------------------------------------------------------------- */
 /*                         Basic Definitions                                  */
 /* -------------------------------------------------------------------------- */
 
@@ -1899,6 +1922,7 @@ export type NubeComponent =
 	| NubeComponentToastDescription
 	| NubeComponentIcon
 	| NubeComponentSideScroll
+	| NubeComponentMarkdown
 	| NubeComponentSvg
 	| NubeComponentCircle
 	| NubeComponentPath

--- a/packages/ui/src/components/markdown.ts
+++ b/packages/ui/src/components/markdown.ts
@@ -1,0 +1,22 @@
+import type {
+	NubeComponentMarkdown,
+	NubeComponentMarkdownProps,
+} from "@tiendanube/nube-sdk-types";
+import { generateInternalId } from "./generateInternalId";
+
+/**
+ * Creates a `markdown` component.
+ *
+ * The `markdown` component is used to render markdown content.
+ * It supports properties such as `content` for the markdown string.
+ *
+ * @param props - The properties for configuring the markdown component.
+ * @returns A `NubeComponentMarkdown` object representing the markdown component.
+ */
+export const markdown = (
+	props: NubeComponentMarkdownProps,
+): NubeComponentMarkdown => ({
+	type: "markdown",
+	...props,
+	__internalId: generateInternalId("markdown", props),
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,6 +21,7 @@ export * from "./components/toast-root";
 export * from "./components/toast-title";
 export * from "./components/toast-description";
 export * from "./components/icon";
+export * from "./components/markdown";
 export * from "./components/side-scroll";
 export * from "./components/svg-root";
 export * from "./components/svg-circle";


### PR DESCRIPTION
## Description

This PR introduces a new `markdown` component to the SDK, enabling developers to render markdown content within their applications.

## Related PR's

- https://github.com/TiendaNube/nube-sdk-internal/pull/133

## Example Usage

```typescript
import { Markdown } from "@tiendanube/nube-sdk-jsx";
import type { NubeSDK } from "@tiendanube/nube-sdk-types";

export function App(nube: NubeSDK) {
	nube.render("before_main_content", () => <Markdown content={`
    ### Title
    This ***is*** a **markdown**
  `} />);
}
```