### PR TITLE
release(nube-devtools): bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10203,7 +10203,7 @@
       }
     },
     "packages/nube-devtools": {
-      "version": "0.0.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",

--- a/packages/nube-devtools/package.json
+++ b/packages/nube-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nube-devtools",
   "displayName": "nube-devtools",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "author": "Tiendanube / Nuvemshop",
   "description": "Chrome DevTools extension for debugging and testing NubeSDK apps with real-time insights.",
   "type": "module",


### PR DESCRIPTION
This pull request updates the version of the `nube-devtools` package to indicate a major release.

* Version bump: Updated the version in `package.json` from `0.0.6` to `1.0.0`, signaling a major release for the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released Nube DevTools version 1.0.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->