### PR TITLE
chore(types): add new drawer slots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10426,7 +10426,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.52.0",
+	"version": "0.53.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -18,6 +18,8 @@ import type { ObjectValues, Prettify } from "./utility";
  * @property {"before_line_items"} BEFORE_LINE_ITEMS - Before the list of items in the cart.
  * @property {"after_line_items"} AFTER_LINE_ITEMS - After the list of items in the cart.
  * @property {"after_header"} AFTER_HEADER - After the header.
+ * @property {"drawer_left"} DRAWER_LEFT - Left drawer.
+ * @property {"drawer_right"} DRAWER_RIGHT - Right drawer.
  */
 export const COMMON_UI_SLOT = {
 	BEFORE_MAIN_CONTENT: "before_main_content",
@@ -30,6 +32,8 @@ export const COMMON_UI_SLOT = {
 	BEFORE_LINE_ITEMS: "before_line_items",
 	AFTER_LINE_ITEMS: "after_line_items",
 	AFTER_HEADER: "after_header",
+	DRAWER_LEFT: "drawer_left",
+	DRAWER_RIGHT: "drawer_right",
 } as const;
 
 /**


### PR DESCRIPTION
# Add drawer slots

## Description

This PR adds support for drawer slots in the UI slot system and bumps the types package version.

## Changes

- **Added drawer slots**: Introduced two new common UI slots:
  - `drawer_left` - Left drawer slot
  - `drawer_right` - Right drawer slot
  
  These slots are added to `COMMON_UI_SLOT`, making them available in both checkout and storefront contexts.

- **Version bump**: Updated `@tiendanube/nube-sdk-types` from `0.52.0` to `0.53.0`

## Impact

These drawer slots enable developers to inject UI components into left and right drawer areas across checkout and storefront interfaces, providing more customization options for the user interface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for left and right drawer UI slots.

* **Chores**
  * Version bump to 0.53.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->