### PR TITLE
[Security] Migrate CircleCI from microservices context to extensibility-context (main)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,17 +127,17 @@ workflows:
   build-and-publish:
     jobs:
       - install_dependencies:
-          context: productivity-context
+          context: extensibility-context
       - check_style:
-          context: productivity-context
+          context: extensibility-context
           requires:
             - install_dependencies
       - run_tests:
-          context: productivity-context
+          context: extensibility-context
           requires:
             - check_style
       - build:
-          context: productivity-context
+          context: extensibility-context
           requires:
             - run_tests
       - approval-publish-types:


### PR DESCRIPTION
- Replace 4x context: microservices → context: extensibility-context
- No AWS usage — Node.js build/test/publish pipeline only
- NPM_TOKEN_SDK context on publish jobs unchanged
- No OIDC changes needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CircleCI configuration to use a different context for build and publish workflows.

**Note:** This is an internal infrastructure update with no impact on product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->