### PR TITLE
feat(devtools): integrate error handling in apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10203,7 +10203,7 @@
       }
     },
     "packages/nube-devtools": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",

--- a/packages/nube-devtools/package.json
+++ b/packages/nube-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nube-devtools",
   "displayName": "nube-devtools",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Tiendanube / Nuvemshop",
   "description": "Chrome DevTools extension for debugging and testing NubeSDK apps with real-time insights.",
   "type": "module",

--- a/packages/nube-devtools/src/background/types.ts
+++ b/packages/nube-devtools/src/background/types.ts
@@ -2,6 +2,7 @@ export type NubeSDKApp = {
 	id: string;
 	registered: boolean;
 	script: string;
+	errors?: string[];
 };
 
 export type NubeSDKComponent = {

--- a/packages/nube-devtools/src/components/ui/alert.tsx
+++ b/packages/nube-devtools/src/components/ui/alert.tsx
@@ -1,0 +1,61 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+	"flex gap-3 w-full rounded-lg border px-4 py-3 [&>svg]:size-4 [&>svg]:shrink-0",
+	{
+		variants: {
+			variant: {
+				default:
+					"bg-background text-foreground border-border [&>svg]:text-foreground",
+				destructive:
+					"border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive [&>svg]:text-destructive",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+function Alert({
+	className,
+	variant,
+	...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+	return (
+		<div
+			data-slot="alert"
+			role="alert"
+			className={cn(alertVariants({ variant }), className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="alert-title"
+			className={cn("font-medium leading-none tracking-tight", className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDescription({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="alert-description"
+			className={cn("text-sm [&_p]:leading-relaxed", className)}
+			{...props}
+		/>
+	);
+}
+
+export { Alert, AlertDescription, AlertTitle, alertVariants };

--- a/packages/nube-devtools/src/contexts/nube-sdk-apps-context.tsx
+++ b/packages/nube-devtools/src/contexts/nube-sdk-apps-context.tsx
@@ -1,13 +1,10 @@
+import type { NubeSDKApp } from "@/background/types";
 import { createContext, useContext, useState } from "react";
 import type { ReactNode } from "react";
 
 export interface NubeSDKEvent {
 	id: string;
-	data: {
-		id: string;
-		registered: boolean;
-		script: string;
-	};
+	data: NubeSDKApp;
 }
 
 type NubeSDKAppsContextType = {

--- a/packages/nube-devtools/src/devtools/components/json-viewer.tsx
+++ b/packages/nube-devtools/src/devtools/components/json-viewer.tsx
@@ -103,7 +103,7 @@ export function JsonViewer({
 				collapsed={collapsed}
 				displayDataTypes={false}
 				iconStyle="circle"
-				enableClipboard={false}
+				enableClipboard
 				style={{
 					backgroundColor: "transparent",
 				}}

--- a/packages/nube-devtools/src/devtools/components/table-row-item.tsx
+++ b/packages/nube-devtools/src/devtools/components/table-row-item.tsx
@@ -1,6 +1,7 @@
-import { Badge } from "@/components/ui/badge";
+import { Badge, type badgeVariants } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { TableCell } from "@/components/ui/table";
+import type { VariantProps } from "class-variance-authority";
 import { Repeat } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -14,6 +15,7 @@ type TableRowItemProps<T> = {
 	title: string;
 	badge1?: string;
 	badge2?: string;
+	badge2Variant?: VariantProps<typeof badgeVariants>["variant"];
 	isSelected: boolean;
 	onSelect: (event: Event<T>) => void;
 	onResend?: (event: Event<T>) => void;
@@ -27,6 +29,7 @@ export function TableRowItem<T>({
 	title: text,
 	badge1,
 	badge2,
+	badge2Variant = "outline",
 }: TableRowItemProps<T>) {
 	const [isHighlighted, setIsHighlighted] = useState(true);
 
@@ -61,7 +64,7 @@ export function TableRowItem<T>({
 						</Badge>
 					)}
 					{badge2 && (
-						<Badge className="text-[10px] px-1 py-0.5" variant="outline">
+						<Badge className="text-[10px] px-1 py-0.5" variant={badge2Variant}>
 							{badge2}
 						</Badge>
 					)}

--- a/packages/nube-devtools/src/devtools/pages/state.tsx
+++ b/packages/nube-devtools/src/devtools/pages/state.tsx
@@ -82,21 +82,23 @@ export function State() {
 	return (
 		<Layout>
 			<div className="flex h-full flex-col">
-				<nav className="flex items-center px-1.5 justify-between py-1 border-b h-[33px] shrink-0">
-					<SidebarTrigger />
-					<div className="flex items-center gap-2">
-						<UpdatedAt timestamp={updatedAt} />
-						<Button
-							variant="ghost"
-							size="icon"
-							className="h-6 w-6"
-							onClick={fetchState}
-							disabled={loading}
-						>
-							<RefreshCwIcon
-								className={`size-3 ${loading ? "animate-spin" : ""}`}
-							/>
-						</Button>
+				<nav className="flex items-center justify-between px-1.5 py-1 border-b h-[33px] shrink-0">
+					<div className="flex items-center">
+						<SidebarTrigger />
+						<Divider />
+						<div className="flex items-center gap-2">
+							<Button
+								variant="ghost"
+								size="icon"
+								className="h-6 w-6"
+								onClick={fetchState}
+								disabled={loading}
+							>
+								<RefreshCwIcon
+									className={`size-3 ${loading ? "animate-spin" : ""}`}
+								/>
+							</Button>
+						</div>
 					</div>
 				</nav>
 				<div className="flex-1 overflow-y-auto p-2">

--- a/packages/nube-devtools/src/devtools/pages/unavailable.tsx
+++ b/packages/nube-devtools/src/devtools/pages/unavailable.tsx
@@ -33,12 +33,12 @@ export const Unavailable = () => {
 				<p className="text-gray-300 text-center mt-4">
 					Check out our{" "}
 					<a
-						href="https://github.com/TiendaNube/nube-sdk"
+						href="https://dev.nuvemshop.com.br/docs/applications/nube-sdk/overview"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="text-gray-300 hover:text-gray-400 font-bold"
 					>
-						GitHub repository
+						documentation
 					</a>{" "}
 					to learn more about the NubeSDK.
 				</p>


### PR DESCRIPTION
### Descriptions

- Add error handling support to the Apps page in nube-devtools, displaying per-app error counts as badges in the list and a detailed destructive alert with all error messages in the detail panel
- Introduce a reusable Alert component (with default and destructive variants) and extend NubeSDKApp type with an optional errors field
- Improve UX consistency: add refresh button to Apps nav bar, align nav layout with State page using Divider, enable clipboard on JSON viewer, and update the "Unavailable" page link to point to the official documentation

### Screenshots

<img width="1281" height="668" alt="Captura de Tela 2026-02-12 às 18 40 58" src="https://github.com/user-attachments/assets/665231ba-06d0-4031-a282-4f38666e2869" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alert component system for in-app notifications.
  * Clipboard support added to the JSON viewer.
  * Refresh buttons with success toasts in Apps (and State) views; Reload button on empty Apps state.
  * App error counts shown as badges and detailed destructive error alerts in app panel.

* **Documentation**
  * Help link updated to official documentation.

* **Style**
  * Layout and panel stability improved; header simplified with clearer controls.

* **Chores**
  * Package version bumped to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->