### PR TITLE
fix(devtools): include panel.html in production build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10203,7 +10203,7 @@
       }
     },
     "packages/nube-devtools": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
@@ -10426,7 +10426,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.54.0",
+      "version": "0.55.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/nube-devtools/package.json
+++ b/packages/nube-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nube-devtools",
   "displayName": "nube-devtools",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Tiendanube / Nuvemshop",
   "description": "Chrome DevTools extension for debugging and testing NubeSDK apps with real-time insights.",
   "type": "module",

--- a/packages/nube-devtools/vite.config.ts
+++ b/packages/nube-devtools/vite.config.ts
@@ -12,6 +12,9 @@ export default defineConfig(({ mode }) => {
       emptyOutDir: true,
       outDir: 'build',
       rollupOptions: {
+        input: {
+          panel: 'panel.html',
+        },
         output: {
           chunkFileNames: 'assets/chunk-[hash].js',
         },


### PR DESCRIPTION
## Summary

- Fix `panel.html` not being included in the production build, causing the devtools panel to show "It may have been moved, edited, or deleted" when loading the built extension

## Root cause

In #164, `devtools.html` was refactored to use a `bootstrap.ts` that dynamically creates the panel via `chrome.devtools.panels.create("panel.html")`. Since this reference is dynamic, CRXJS/Vite cannot detect it through static analysis, so `panel.html` was never emitted to the `build/` output. The dev server worked because it serves all project files directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.1.1
  * Build configuration updated to optimize entry point detection and chunk generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->