### PR TITLE
feat(types): add before_newsletter slot (EXT-141)

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.55.0",
+	"version": "0.56.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -111,6 +111,7 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_cart_summary"} AFTER_CART_SUMMARY - After the cart summary.
  * @property {"before_footer"} BEFORE_FOOTER - Before the footer.
  * @property {"cart_line_item_top"} CART_LINE_ITEM_TOP - Top of the cart line item.
+ * @property {"before_newsletter"} BEFORE_NEWSLETTER - Before the newsletter section.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -142,6 +143,7 @@ export const STOREFRONT_UI_SLOT = {
 	BEFORE_FOOTER: "before_footer",
 	CART_LINE_ITEM_TOP: "cart_line_item_top",
 	BEFORE_PRODUCT_DETAIL_NAME: "before_product_detail_name",
+	BEFORE_NEWSLETTER: "before_newsletter",
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- Adds `BEFORE_NEWSLETTER` to `STOREFRONT_UI_SLOT` in `packages/types/src/slots.ts`
- Bumps `@tiendanube/nube-sdk-types` from `0.55.0` to `0.56.0`

## Changes

| File | Change |
|------|--------|
| `packages/types/src/slots.ts` | Added `BEFORE_NEWSLETTER: "before_newsletter"` entry and JSDoc annotation |
| `packages/types/package.json` | Bumped version `0.55.0` → `0.56.0` |

## Related

- Issue: EXT-141

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new customization slot for the area before the newsletter section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->