### PR TITLE
chore(create-nube-app): bump package versions for create-nube-app and dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9845,7 +9845,7 @@
       }
     },
     "packages/create-nube-app": {
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
@@ -10203,7 +10203,7 @@
       }
     },
     "packages/nube-devtools": {
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
@@ -10426,7 +10426,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.55.0",
+      "version": "0.56.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/create-nube-app/package.json
+++ b/packages/create-nube-app/package.json
@@ -3,7 +3,7 @@
 	"description": "Create Nube App",
 	"author": "Tiendanube / Nuvemshop",
 	"license": "MIT",
-	"version": "0.23.0",
+	"version": "0.24.0",
 	"bin": {
 		"create-nube-app": "dist/index.js"
 	},

--- a/packages/create-nube-app/templates/minimal-ui-jsx/package.json
+++ b/packages/create-nube-app/templates/minimal-ui-jsx/package.json
@@ -16,7 +16,7 @@
 		"@biomejs/biome": "^1.9.4",
 		"@tiendanube/nube-sdk-ui": "^0.17.0",
 		"@tiendanube/nube-sdk-jsx": "^0.16.0",
-		"@tiendanube/nube-sdk-types": "^0.53.0",
+		"@tiendanube/nube-sdk-types": "^0.56.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/create-nube-app/templates/minimal-ui/package.json
+++ b/packages/create-nube-app/templates/minimal-ui/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@tiendanube/nube-sdk-ui": "^0.17.0",
-		"@tiendanube/nube-sdk-types": "^0.53.0",
+		"@tiendanube/nube-sdk-types": "^0.56.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",

--- a/packages/create-nube-app/templates/minimal/package.json
+++ b/packages/create-nube-app/templates/minimal/package.json
@@ -13,7 +13,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-types": "^0.53.0",
+		"@tiendanube/nube-sdk-types": "^0.56.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",
 		"serve": "^14.2.4",


### PR DESCRIPTION
## Description

This pull request updates the version of the `create-nube-app` package and bumps the `@tiendanube/nube-sdk-types` dependency in all minimal template projects. These changes ensure that new apps generated with these templates will use the latest features and bug fixes from the SDK types package.

Version update:

* Increased the version of `create-nube-app` to `0.24.0` in `packages/create-nube-app/package.json` for a new release.

Dependency updates in templates:

* Updated `@tiendanube/nube-sdk-types` to version `^0.56.0` in the following template `package.json` files:
  - `minimal-ui-jsx`
  - `minimal-ui`
  - `minimal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped create-nube-app to version 0.24.0
  * Updated SDK types dependencies to the latest version across all project templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->