### PR TITLE
fix: use value instead of placeholder for issue template guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,22 +8,22 @@ body:
     attributes:
       label: Bug Description
       description: Tell us what happened. The more detail you provide, the faster we can help.
-      placeholder: |
+      value: |
         **What happened?**
-        Describe the bug clearly.
+
 
         **Steps to reproduce**
-        1. ...
-        2. ...
-        3. ...
+        1.
+        2.
+        3.
 
         **Expected behavior**
-        What did you expect to happen?
+
 
         **Environment (optional)**
-        NubeSDK version, browser, OS, etc.
+
 
         **Logs or screenshots (optional)**
-        Paste any relevant error messages or attach screenshots.
+
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -8,17 +8,17 @@ body:
     attributes:
       label: Feature Description
       description: Tell us what you'd like to see in NubeSDK.
-      placeholder: |
+      value: |
         **What problem does this solve?**
-        Describe the limitation or pain point.
+
 
         **Proposed solution**
-        How would you like this to work?
+
 
         **Use case (optional)**
-        Describe the scenario where this would help.
+
 
         **Alternatives considered (optional)**
-        Have you tried any workarounds?
+
     validations:
       required: true


### PR DESCRIPTION
## Summary

- Change issue templates from `placeholder` to `value` so the guide text stays visible as a pre-filled template that users edit directly, instead of disappearing when they start typing.

## Context

Follow-up to #175. After testing, we noticed the placeholder text disappears when users start typing, which defeats the purpose of guiding them through the template structure.

## Test plan

- [ ] Open https://github.com/TiendaNube/nube-sdk/issues/new?template=bug-report.yml and confirm the template text is pre-filled (not a gray placeholder)
- [ ] Open https://github.com/TiendaNube/nube-sdk/issues/new?template=feature-request.yml and confirm the same
- [ ] Verify users can edit the pre-filled text directly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed issue templates for Bug Reports and Feature Requests with cleaner formatting, simplified examples, and improved guidance structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->