### PR TITLE
feat: add App ID and App name fields to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -3,6 +3,22 @@ description: Report a bug in NubeSDK
 title: "[BUG] "
 labels: ["bug"]
 body:
+  - type: input
+    id: app-id
+    attributes:
+      label: App ID
+      description: Your application ID.
+      placeholder: "e.g. 12345"
+    validations:
+      required: true
+
+  - type: input
+    id: app-name
+    attributes:
+      label: App name
+      description: Your application name (optional).
+      placeholder: "e.g. My Payments App"
+
   - type: textarea
     id: bug-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,6 +3,20 @@ description: Suggest a new feature or improvement for NubeSDK
 title: "[REQUEST] "
 labels: ["enhancement"]
 body:
+  - type: input
+    id: app-id
+    attributes:
+      label: App ID
+      description: Your application ID, if you already have one.
+      placeholder: "e.g. 12345"
+
+  - type: input
+    id: app-name
+    attributes:
+      label: App name
+      description: Your application name (optional).
+      placeholder: "e.g. My Payments App"
+
   - type: textarea
     id: feature-description
     attributes:


### PR DESCRIPTION
## Summary

- Add **App ID** and **App name** input fields to both issue templates
- Bug report: App ID is **required**, App name is optional
- Feature request: both are **optional** (partner may not have an app yet)
- Fields appear at the top of the form, before the description textarea

## Why

Enables grouping issues by partner using App ID as a consistent key. This also prepares for future integration with Linear's Customers feature, where each partner can be tracked as a Customer linked by App ID.

## Test plan

- [ ] Open bug report template and confirm App ID (required) and App name (optional) fields appear
- [ ] Open feature request template and confirm both fields appear as optional
- [ ] Submit a bug without App ID and confirm validation blocks it
- [ ] Submit a feature request without App ID and confirm it goes through

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced bug report and feature request templates with new app identification fields (app-id and app-name) to improve issue tracking and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->