### PR TITLE
refactor: use Partner Request label and clean up unused labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement for NubeSDK
 title: "[REQUEST] "
-labels: ["enhancement"]
+labels: ["Partner Request"]
 body:
   - type: input
     id: app-id

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,14 +27,4 @@ You can also check the **[official NubeSDK documentation](https://dev.tiendanube
 
 ## Issue Lifecycle
 
-When you open an issue, it enters our triage process. You can track its progress through labels applied to the issue.
-
-### Status Labels
-
-| Label | Meaning |
-|---|---|
-| `status:in-review` | The issue is being reviewed by the team |
-| `status:planned` | The issue has been accepted and is planned for development |
-| `status:in-progress` | The issue is actively being worked on |
-| `status:completed` | The issue has been resolved |
-| `status:rejected` | The issue has been declined (a reason will be provided) |
+When you open an issue, it enters our triage process. You can track its progress through the issue's open/closed status on GitHub.


### PR DESCRIPTION
## Summary

- Change feature request template label from `enhancement` to `Partner Request` (matches Linear's Type label group)
- Remove status labels table from `CONTRIBUTING.md` (status is tracked via open/closed only)
- 9 labels already removed from GitHub via API: `status:in-review`, `status:planned`, `status:in-progress`, `status:completed`, `status:rejected`, `priority:urgent`, `priority:high`, `priority:medium`, `priority:low`
- Created new `Partner Request` label on GitHub

## Why

Status and priority labels were not being synced from Linear, so they had no utility on GitHub. Status is now communicated via the native open/closed state. The `Partner Request` label aligns with the Linear Type label used by the internal team.

## Test plan

- [ ] Open feature request template and confirm `Partner Request` label is applied
- [ ] Confirm `CONTRIBUTING.md` no longer references status labels
- [ ] Verify the 9 removed labels no longer appear in the repo's label list

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated contributor guidelines with streamlined issue status information.
  * Modified feature request issue template labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->