### PR TITLE
feat: add severity dropdown to bug report with Linear priority sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -19,6 +19,17 @@ body:
       description: Your application name (optional).
       placeholder: "e.g. My Payments App"
 
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug?
+      options:
+        - "Urgent - My app and stores are impacted right now"
+        - "High - Core functionality is broken but there is a workaround"
+        - "Medium - Something is not working as expected but does not block usage"
+        - "Low - Minor issue or visual glitch"
+
   - type: textarea
     id: bug-description
     attributes:

--- a/.github/workflows/sync-severity-to-linear.yml
+++ b/.github/workflows/sync-severity-to-linear.yml
@@ -1,0 +1,136 @@
+name: Sync Severity to Linear Priority
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: read
+
+jobs:
+  sync-priority:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const issueNumber = context.payload.issue.number;
+
+            const severityMap = {
+              'Urgent': 1,
+              'High': 2,
+              'Medium': 3,
+              'Low': 4,
+            };
+
+            let priority = null;
+            for (const [key, value] of Object.entries(severityMap)) {
+              if (body.includes(`${key} -`)) {
+                priority = value;
+                break;
+              }
+            }
+
+            if (!priority) {
+              core.info('No severity selected, skipping priority sync.');
+              return;
+            }
+
+            core.info(`Severity detected: priority level ${priority}`);
+
+            const linearApiKey = process.env.LINEAR_API_KEY;
+            const linearTeamId = process.env.LINEAR_TEAM_ID;
+
+            if (!linearApiKey || !linearTeamId) {
+              core.setFailed('LINEAR_API_KEY or LINEAR_TEAM_ID secret is not configured.');
+              return;
+            }
+
+            const maxAttempts = 5;
+            const delayMs = 10000;
+            let linearIssueId = null;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              core.info(`Attempt ${attempt}: searching for issue #${issueNumber} in Linear...`);
+
+              const searchQuery = `
+                query($teamId: String!) {
+                  issues(filter: {
+                    team: { id: { eq: $teamId } }
+                    attachments: { url: { contains: "${context.repo.repo}/issues/${issueNumber}" } }
+                  }) {
+                    nodes {
+                      id
+                      identifier
+                    }
+                  }
+                }
+              `;
+
+              const response = await fetch('https://api.linear.app/graphql', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': linearApiKey,
+                },
+                body: JSON.stringify({
+                  query: searchQuery,
+                  variables: { teamId: linearTeamId },
+                }),
+              });
+
+              const data = await response.json();
+
+              if (data.data?.issues?.nodes?.length > 0) {
+                linearIssueId = data.data.issues.nodes[0].id;
+                core.info(`Found Linear issue: ${data.data.issues.nodes[0].identifier} (${linearIssueId})`);
+                break;
+              }
+
+              if (attempt < maxAttempts) {
+                core.info(`Issue not found in Linear yet, waiting ${delayMs / 1000}s...`);
+                await new Promise(r => setTimeout(r, delayMs));
+              }
+            }
+
+            if (!linearIssueId) {
+              core.warning(`Could not find GitHub issue #${issueNumber} in Linear after ${maxAttempts} attempts.`);
+              return;
+            }
+
+            const updateQuery = `
+              mutation($issueId: String!, $priority: Int!) {
+                issueUpdate(id: $issueId, input: { priority: $priority }) {
+                  success
+                  issue {
+                    identifier
+                    priority
+                  }
+                }
+              }
+            `;
+
+            const updateResponse = await fetch('https://api.linear.app/graphql', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': linearApiKey,
+              },
+              body: JSON.stringify({
+                query: updateQuery,
+                variables: { issueId: linearIssueId, priority: priority },
+              }),
+            });
+
+            const updateData = await updateResponse.json();
+
+            if (updateData.data?.issueUpdate?.success) {
+              core.info(`Priority updated to ${priority} for ${updateData.data.issueUpdate.issue.identifier}`);
+            } else {
+              core.setFailed(`Failed to update priority: ${JSON.stringify(updateData)}`);
+            }


### PR DESCRIPTION
## Summary

- Add **Severity** dropdown (optional) to bug report template with user-friendly options:
  - Urgent - My app and stores are impacted right now
  - High - Core functionality is broken but there is a workaround
  - Medium - Something is not working as expected but does not block usage
  - Low - Minor issue or visual glitch
- Add `sync-severity-to-linear.yml` GitHub Action that automatically sets the priority in Linear based on the selected severity

## How it works

1. Partner opens a bug report and selects a severity level
2. The GitHub Action triggers on issue creation
3. It waits for the Linear integration to create the corresponding item (retries up to 5 times with 10s intervals)
4. It calls the Linear GraphQL API to set the priority field (1=Urgent, 2=High, 3=Medium, 4=Low)

## Requirements

Two repository secrets must be configured (already done):
- `LINEAR_API_KEY` - Linear API key with write access
- `LINEAR_TEAM_ID` - UUID of the Linear team (EXT)

## Test plan

- [ ] Open a bug report and select "Urgent" severity
- [ ] Wait ~30s and verify the Linear item has priority set to "Urgent"
- [ ] Open a bug report without selecting severity and confirm no priority is set in Linear
- [ ] Verify the Action logs show the correct flow in Actions tab

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a severity level dropdown to the bug report template with four options: Urgent, High, Medium, and Low.
  * Bug severity is now automatically tracked when creating issue reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->