### PR TITLE
fix: search Linear issue by title instead of attachment URL

### DIFF
--- a/.github/workflows/sync-severity-to-linear.yml
+++ b/.github/workflows/sync-severity-to-linear.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           script: |
             const body = context.payload.issue.body || '';
+            const issueTitle = context.payload.issue.title;
             const issueNumber = context.payload.issue.number;
 
             const severityMap = {
@@ -42,6 +43,7 @@ jobs:
             }
 
             core.info(`Severity detected: priority level ${priority}`);
+            core.info(`Looking for Linear issue with title: "${issueTitle}"`);
 
             const linearApiKey = process.env.LINEAR_API_KEY;
             const linearTeamId = process.env.LINEAR_TEAM_ID;
@@ -51,44 +53,59 @@ jobs:
               return;
             }
 
-            const maxAttempts = 5;
-            const delayMs = 10000;
-            let linearIssueId = null;
-
-            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-              core.info(`Attempt ${attempt}: searching for issue #${issueNumber} in Linear...`);
-
-              const searchQuery = `
-                query($teamId: String!) {
-                  issues(filter: {
-                    team: { id: { eq: $teamId } }
-                    attachments: { url: { contains: "${context.repo.repo}/issues/${issueNumber}" } }
-                  }) {
-                    nodes {
-                      id
-                      identifier
-                    }
-                  }
-                }
-              `;
-
+            async function queryLinear(query, variables = {}) {
               const response = await fetch('https://api.linear.app/graphql', {
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/json',
                   'Authorization': linearApiKey,
                 },
-                body: JSON.stringify({
-                  query: searchQuery,
-                  variables: { teamId: linearTeamId },
-                }),
+                body: JSON.stringify({ query, variables }),
+              });
+              return response.json();
+            }
+
+            const maxAttempts = 6;
+            const delayMs = 15000;
+            let linearIssueId = null;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              core.info(`Attempt ${attempt}/${maxAttempts}: searching for issue in Linear...`);
+
+              const searchQuery = `
+                query($teamId: String!, $title: String!) {
+                  issues(
+                    filter: {
+                      team: { id: { eq: $teamId } }
+                      title: { containsIgnoreCase: $title }
+                    }
+                    orderBy: createdAt
+                    last: 5
+                  ) {
+                    nodes {
+                      id
+                      identifier
+                      title
+                      createdAt
+                    }
+                  }
+                }
+              `;
+
+              const data = await queryLinear(searchQuery, {
+                teamId: linearTeamId,
+                title: issueTitle,
               });
 
-              const data = await response.json();
+              if (data.errors) {
+                core.warning(`Linear API error: ${JSON.stringify(data.errors)}`);
+              }
 
-              if (data.data?.issues?.nodes?.length > 0) {
-                linearIssueId = data.data.issues.nodes[0].id;
-                core.info(`Found Linear issue: ${data.data.issues.nodes[0].identifier} (${linearIssueId})`);
+              const nodes = data.data?.issues?.nodes || [];
+
+              if (nodes.length > 0) {
+                linearIssueId = nodes[0].id;
+                core.info(`Found Linear issue: ${nodes[0].identifier} - "${nodes[0].title}" (${linearIssueId})`);
                 break;
               }
 
@@ -99,7 +116,7 @@ jobs:
             }
 
             if (!linearIssueId) {
-              core.warning(`Could not find GitHub issue #${issueNumber} in Linear after ${maxAttempts} attempts.`);
+              core.warning(`Could not find Linear issue matching title "${issueTitle}" after ${maxAttempts} attempts. The team may need to set priority manually.`);
               return;
             }
 
@@ -115,19 +132,10 @@ jobs:
               }
             `;
 
-            const updateResponse = await fetch('https://api.linear.app/graphql', {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'Authorization': linearApiKey,
-              },
-              body: JSON.stringify({
-                query: updateQuery,
-                variables: { issueId: linearIssueId, priority: priority },
-              }),
+            const updateData = await queryLinear(updateQuery, {
+              issueId: linearIssueId,
+              priority: priority,
             });
-
-            const updateData = await updateResponse.json();
 
             if (updateData.data?.issueUpdate?.success) {
               core.info(`Priority updated to ${priority} for ${updateData.data.issueUpdate.issue.identifier}`);


### PR DESCRIPTION
## Summary

- Fix `sync-severity-to-linear.yml` to search Linear issues by **title** (`containsIgnoreCase`) instead of by GitHub issue number in attachment URLs
- Increase retry attempts from 5 to 6 and delay from 10s to 15s to account for sync latency

## Problem

The previous approach searched for the Linear issue using the GitHub issue number in attachment URLs, but Linear does not store synced issues that way. This caused the Action to fail with "Could not find GitHub issue #N in Linear after 5 attempts."

## Test plan

- [ ] Open a bug report with severity selected
- [ ] Check Actions tab and confirm the issue is found in Linear by title
- [ ] Verify the priority is set correctly in Linear

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced issue synchronization reliability with increased retry attempts and delays.
  * Improved error handling and validation for missing configuration.
  * Better logging and progress visibility during issue syncing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->