### PR TITLE
fix: use correct GraphQL types for Linear API variables

### DIFF
--- a/.github/workflows/sync-severity-to-linear.yml
+++ b/.github/workflows/sync-severity-to-linear.yml
@@ -73,7 +73,7 @@ jobs:
               core.info(`Attempt ${attempt}/${maxAttempts}: searching for issue in Linear...`);
 
               const searchQuery = `
-                query($teamId: String!, $title: String!) {
+                query($teamId: ID!, $title: String!) {
                   issues(
                     filter: {
                       team: { id: { eq: $teamId } }
@@ -121,7 +121,7 @@ jobs:
             }
 
             const updateQuery = `
-              mutation($issueId: String!, $priority: Int!) {
+              mutation($issueId: ID!, $priority: Int!) {
                 issueUpdate(id: $issueId, input: { priority: $priority }) {
                   success
                   issue {


### PR DESCRIPTION
## Summary

- Fix `$teamId` type from `String!` to `ID!` in the search query
- Fix `$issueId` type from `String!` to `ID!` in the update mutation

## Problem

The Linear GraphQL API expects `ID` type for entity identifiers, not `String`. This caused all API calls to fail with `GRAPHQL_VALIDATION_FAILED`.

## Test plan

- [ ] Open a bug report with severity selected
- [ ] Check Actions tab for successful Linear API calls
- [ ] Verify priority is set in Linear

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type definitions for internal workflow operations to improve type consistency and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->