### PR TITLE
fix: use correct type for issueUpdate mutation

### DIFF
--- a/.github/workflows/sync-severity-to-linear.yml
+++ b/.github/workflows/sync-severity-to-linear.yml
@@ -121,7 +121,7 @@ jobs:
             }
 
             const updateQuery = `
-              mutation($issueId: ID!, $priority: Int!) {
+              mutation($issueId: String!, $priority: Int!) {
                 issueUpdate(id: $issueId, input: { priority: $priority }) {
                   success
                   issue {


### PR DESCRIPTION
## Summary

- Change `$issueId` back to `String!` in the `issueUpdate` mutation (Linear expects `String!` here, not `ID!`)

## Context

The search query needs `ID!` for team filter, but the `issueUpdate` mutation needs `String!` for the issue id. Different endpoints, different types.

## Test plan

- [ ] Open a bug report with severity selected
- [ ] Verify priority is set correctly in Linear

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflow configuration. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->