### PR TITLE
feat(types): add order extra metadata and order:add:extra sendable event

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.60.0",
+	"version": "0.61.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -334,6 +334,9 @@ export type Order = {
 
 	/** Tracking statuses of the order. */
 	tracking_statuses?: OrderTrackingStatus[];
+
+	/** Additional metadata for the order, set by partner apps. */
+	extra?: Record<string, string>;
 };
 
 /**

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -23,6 +23,7 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  * @property {"coupon:add"} COUPON_ADD - Used to add a coupon to the cart.
  * @property {"coupon:remove"} COUPON_REMOVE - Used to remove a coupon from the cart.
  * @property {"shipping:select"} SHIPPING_SELECT - Used to select shipping option.
+ * @property {"order:add:extra"} ORDER_ADD_EXTRA - Used to add additional metadata to an order.
  */
 export const SENDABLE_EVENT = {
 	CART_VALIDATE: "cart:validate",
@@ -32,6 +33,7 @@ export const SENDABLE_EVENT = {
 	UI_SLOT_SET: "ui:slot:set",
 	SHIPPING_UPDATE_LABEL: "shipping:update:label",
 	ORDER_ADD_TRACKING_STATUSES: "order:add:tracking_statuses",
+	ORDER_ADD_EXTRA: "order:add:extra",
 	COUPON_ADD: "coupon:add",
 	COUPON_REMOVE: "coupon:remove",
 	SHIPPING_SELECT: "shipping:select",


### PR DESCRIPTION
## related pr

- https://github.com/TiendaNube/nube-sdk-internal/pull/173
- https://github.com/TiendaNube/services-checkout/pull/4677

## issue
[Linear - Possibilidade de persistir metadados (extra_attributes) na ordem via SDK](https://linear.app/nuvemshop-tiendanube/issue/EXT-311/possibilidade-de-persistir-metadados-extra-attributes-na-ordem-via-sdk)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orders can include configurable partner-provided metadata.
  * Added a new order creation event notification type.
* **Chores**
  * Package version bumped to reflect the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->