### PR TITLE
feat: add new PDP and cart slots

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.61.0",
+	"version": "0.62.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -192,10 +192,13 @@ export const STOREFRONT_UI_SLOT = {
 	/** @deprecated Use BEFORE_LINE_ITEM instead. */
 	CART_LINE_ITEM_TOP: "cart_line_item_top",
 	BEFORE_PRODUCT_DETAIL_NAME: "before_product_detail_name",
-	BEFORE_PRODUCT_DETAIL_PAYMENT_OPTIONS: "before_product_detail_payment_options",
+	BEFORE_PRODUCT_DETAIL_PAYMENT_OPTIONS:
+		"before_product_detail_payment_options",
 	AFTER_PRODUCT_DETAIL_PAYMENT_OPTIONS: "after_product_detail_payment_options",
-	BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR: "before_product_detail_shipping_calculator",
-	AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR: "after_product_detail_shipping_calculator",
+	BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
+		"before_product_detail_shipping_calculator",
+	AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
+		"after_product_detail_shipping_calculator",
 	BEFORE_CART_SHIPPING_CALCULATOR: "before_cart_shipping_calculator",
 	AFTER_CART_SHIPPING_CALCULATOR: "after_cart_shipping_calculator",
 } as const;

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -129,6 +129,12 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"before_line_item"} BEFORE_LINE_ITEM - Before each cart line item.
  * @property {"cart_line_item_top"} CART_LINE_ITEM_TOP - Top of the cart line item. Deprecated; use BEFORE_LINE_ITEM instead.
  * @property {"before_footer"} BEFORE_FOOTER - Before the footer.
+ * @property {"before_product_detail_payment_options"} BEFORE_PRODUCT_DETAIL_PAYMENT_OPTIONS - Before the payment options accordion on the product detail page.
+ * @property {"after_product_detail_payment_options"} AFTER_PRODUCT_DETAIL_PAYMENT_OPTIONS - After the payment options accordion on the product detail page.
+ * @property {"before_product_detail_shipping_calculator"} BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR - Before the shipping calculator on the product detail page.
+ * @property {"after_product_detail_shipping_calculator"} AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR - After the shipping calculator on the product detail page.
+ * @property {"before_cart_shipping_calculator"} BEFORE_CART_SHIPPING_CALCULATOR - Before the shipping calculator on the cart page.
+ * @property {"after_cart_shipping_calculator"} AFTER_CART_SHIPPING_CALCULATOR - After the shipping calculator on the cart page.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -186,6 +192,12 @@ export const STOREFRONT_UI_SLOT = {
 	/** @deprecated Use BEFORE_LINE_ITEM instead. */
 	CART_LINE_ITEM_TOP: "cart_line_item_top",
 	BEFORE_PRODUCT_DETAIL_NAME: "before_product_detail_name",
+	BEFORE_PRODUCT_DETAIL_PAYMENT_OPTIONS: "before_product_detail_payment_options",
+	AFTER_PRODUCT_DETAIL_PAYMENT_OPTIONS: "after_product_detail_payment_options",
+	BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR: "before_product_detail_shipping_calculator",
+	AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR: "after_product_detail_shipping_calculator",
+	BEFORE_CART_SHIPPING_CALCULATOR: "before_cart_shipping_calculator",
+	AFTER_CART_SHIPPING_CALCULATOR: "after_cart_shipping_calculator",
 } as const;
 
 /**


### PR DESCRIPTION
Linear: https://linear.app/nuvemshop-tiendanube/issue/EXT-272/reglas-de-negocio-avanzadas

## Summary

- Add 4 new <NubeSDKSlot> components on the Product Detail Page: before/after the payment options accordion and before/after the shipping calculator.
- Add 2 new <NubeSDKSlot> components on the Cart page: before/after the shipping calculator.
- Replace the deprecated before_start_checkout_button slot with the canonical before_go_to_checkout on the Cart page.

## Test evidence

### Before
<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/a4ba5a5f-d9a4-46db-852b-78ce61f72307" />
<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/c07b5ad8-6ac7-4319-82b3-0158ea2065de" />

### After
<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/5702b85d-e75a-4273-b17d-f8a2be090eb2" />
<img width="1920" height="961" alt="image" src="https://github.com/user-attachments/assets/00eefec9-2f2f-4387-8095-2e5da0457d39" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced six new storefront customization extension points: placement areas before/after payment options on product detail pages, and before/after shipping calculator on product detail and cart pages, enabling finer control over storefront layout and component placement.

* **Chores**
  * Type package version updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->