### PR TITLE
ci: notify partner on issue close

### DIFF
--- a/.github/workflows/notify-partner-on-close.yml
+++ b/.github/workflows/notify-partner-on-close.yml
@@ -1,0 +1,95 @@
+name: Notify Partner on Close
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const MARKER = '<!-- notify-partner-on-close -->';
+
+            if (issue.state_reason !== 'completed') {
+              core.info(`Skip: state_reason is "${issue.state_reason}", expected "completed".`);
+              return;
+            }
+
+            const author = issue.user;
+            if (!author) {
+              core.info('Skip: issue has no author (deleted user).');
+              return;
+            }
+
+            if (author.type === 'Bot' || author.login.endsWith('[bot]')) {
+              core.info(`Skip: author "${author.login}" is a bot (issue likely mirrored from Linear).`);
+              return;
+            }
+
+            const externalAssociations = ['NONE', 'CONTRIBUTOR', 'FIRST_TIME_CONTRIBUTOR'];
+            if (!externalAssociations.includes(issue.author_association)) {
+              core.info(`Skip: author_association is "${issue.author_association}" (internal member).`);
+              return;
+            }
+
+            const closedBy = context.payload.sender?.login;
+            if (closedBy && closedBy === author.login) {
+              core.info(`Skip: author "${author.login}" closed their own issue.`);
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 100,
+            });
+
+            const alreadyNotified = comments.some(c => c.body && c.body.includes(MARKER));
+            if (alreadyNotified) {
+              core.info('Skip: issue already has a notify-partner-on-close comment (idempotency).');
+              return;
+            }
+
+            const labels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name));
+            const isBug = labels.includes('bug');
+
+            const bugBody = `${MARKER}
+            Hi @${author.login}!
+
+            The fix for this bug has been delivered. Could you confirm that the issue is resolved on your side?
+
+            If you still see the problem, please reopen this issue with the latest details so we can investigate further.
+
+            best,
+            Extensibility Team`;
+
+            const requestBody = `${MARKER}
+            Hi @${author.login}!
+
+            Good news, your request has been delivered and is now available.
+
+            Could you take a few minutes to test it and let us know if it works as expected? Any feedback on the implementation is very welcome.
+
+            If something isn't working as expected, feel free to reopen this issue or open a new one.
+
+            best,
+            Extensibility Team`;
+
+            const body = (isBug ? bugBody : requestBody).replace(/^            /gm, '');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body,
+            });
+
+            core.info(`Posted notify-partner-on-close comment (${isBug ? 'bug' : 'request'}) on issue #${issue.number} for @${author.login}.`);


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically posts a comment to the issue author when their issue is closed as completed, asking them to validate the delivery.

## Behavior

The workflow runs on `issues.closed` and comments only when **all** conditions are met:

- `state_reason === 'completed'` (skips `not_planned`, `duplicate`, etc.)
- Author is not a bot (skips Linear-mirrored issues)
- `author_association` is external (`NONE`, `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`) — skips internal team members
- Author didn't close their own issue
- Issue hasn't been notified before (idempotency via `<!-- notify-partner-on-close -->` marker)

## Message variants

- **`bug` label present** → asks partner to confirm the fix works on their side
- **Otherwise** → asks partner to test the delivered request and share feedback

Both messages invite the partner to reopen the issue or open a new one if something isn't right.

## Security

- Uses `actions/github-script@v7` (official, GitHub-maintained)
- Minimal permissions: `issues: write`
- No secrets, no external dependencies

## Test plan

- [ ] Merge and close a test issue as `completed` opened by an external contributor → comment is posted
- [ ] Close an issue authored by a bot (Linear mirror) → no comment
- [ ] Close an issue as `not_planned` → no comment
- [ ] Close the same issue twice (reopen + close) → only one comment (idempotency)
- [ ] Close a bug-labeled issue → message mentions "fix for this bug"
- [ ] Close a non-bug issue → message mentions "your request has been delivered"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated notifications to keep issue reporters informed when their reported issues are closed, ensuring timely communication about issue resolution status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->