### PR TITLE
docs(issue-templates): ask partners to open one issue per request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -3,6 +3,11 @@ description: Report a bug in NubeSDK
 title: "[BUG] "
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Please report one bug per issue.** If you found multiple bugs, open a separate issue for each, it helps us fix them faster.
+
   - type: input
     id: app-id
     attributes:
@@ -34,7 +39,7 @@ body:
     id: bug-description
     attributes:
       label: Bug Description
-      description: Tell us what happened. The more detail you provide, the faster we can help.
+      description: Describe one bug. For multiple bugs, open separate issues.
       value: |
         **What happened?**
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,6 +3,11 @@ description: Suggest a new feature or improvement for NubeSDK
 title: "[REQUEST] "
 labels: ["Partner Request"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Please open one issue per request.** If you have multiple requests, open a separate issue for each, it helps us resolve them faster.
+
   - type: input
     id: app-id
     attributes:
@@ -34,7 +39,7 @@ body:
     id: feature-description
     attributes:
       label: Feature Description
-      description: Tell us what you'd like to see in NubeSDK.
+      description: Describe one feature. For multiple requests, open separate issues.
       value: |
         **What problem does this solve?**
 


### PR DESCRIPTION
## Summary

Partners frequently describe multiple unrelated requests in a single issue (e.g. "I need a checkout slot **and** a cart event **and** a new component"). The resulting Linear issue becomes monolithic and hard to prioritize, assign, or resolve in parallel.

This PR adds a short notice to both issue templates asking partners to open one issue per request, plus a subtle reinforcement in the description of the free-text field where the risk actually happens.

## Changes

- **feature-request.yml**
  - New `markdown` block at the top of the form: "Please open one issue per request..."
  - Updated `Feature Description` hint: "Describe one feature. For multiple requests, open separate issues."
- **bug-report.yml**
  - New `markdown` block at the top: "Please report one bug per issue..."
  - Updated `Bug Description` hint: "Describe one bug. For multiple bugs, open separate issues."
- `config.yml` left untouched (already well-configured with `blank_issues_enabled: false` and helpful `contact_links`).

No LLM, no workflow changes, no new secrets. The `value` placeholders of the textareas are preserved to keep the form clean.

## Test plan

- [ ] Merge and open a feature-request test issue via the form - confirm the markdown notice renders as a blockquote above the first field
- [ ] Open a bug-report test issue - same verification
- [ ] Confirm existing workflows still work: `auto-label-request-type`, `sync-severity-to-linear`, `architecture-auto-reply`
- [ ] Over the next few weeks, observe whether new partner issues trend toward single-request scope

## Why this approach

- Preventive: educates partners at the moment they are filing the issue, not after the fact
- Low cost: 2 files changed, 12 insertions, reversible in one PR
- Non-breaking: no existing fields removed, no workflow contracts changed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue templates to include clearer instructions for reporting a single bug or feature request per issue, with guidance to open separate issues for multiple reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->