### PR TITLE
fix: rename slots *_cart_shipping_calculator -> *_cart_shipping_options

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.62.0",
+	"version": "0.63.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -133,8 +133,8 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_product_detail_payment_options"} AFTER_PRODUCT_DETAIL_PAYMENT_OPTIONS - After the payment options accordion on the product detail page.
  * @property {"before_product_detail_shipping_calculator"} BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR - Before the shipping calculator on the product detail page.
  * @property {"after_product_detail_shipping_calculator"} AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR - After the shipping calculator on the product detail page.
- * @property {"before_cart_shipping_calculator"} BEFORE_CART_SHIPPING_CALCULATOR - Before the shipping calculator on the cart page.
- * @property {"after_cart_shipping_calculator"} AFTER_CART_SHIPPING_CALCULATOR - After the shipping calculator on the cart page.
+ * @property {"before_cart_shipping_options"} BEFORE_CART_SHIPPING_OPTIONS - Before the shipping options on the cart page.
+ * @property {"after_cart_shipping_options"} AFTER_CART_SHIPPING_OPTIONS - After the shipping options on the cart page.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -199,8 +199,8 @@ export const STOREFRONT_UI_SLOT = {
 		"before_product_detail_shipping_calculator",
 	AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
 		"after_product_detail_shipping_calculator",
-	BEFORE_CART_SHIPPING_CALCULATOR: "before_cart_shipping_calculator",
-	AFTER_CART_SHIPPING_CALCULATOR: "after_cart_shipping_calculator",
+	BEFORE_CART_SHIPPING_OPTIONS: "before_cart_shipping_options",
+	AFTER_CART_SHIPPING_OPTIONS: "after_cart_shipping_options",
 } as const;
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.63.0

* **Refactor**
  * Cart shipping-related slot identifiers updated with new naming conventions to improve consistency and clarity across the UI slot system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->