### PR TITLE
fix: rename slot *_shipping_calculator -> *_shipping_options

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.63.0",
+	"version": "0.64.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -131,8 +131,8 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"before_footer"} BEFORE_FOOTER - Before the footer.
  * @property {"before_product_detail_payment_options"} BEFORE_PRODUCT_DETAIL_PAYMENT_OPTIONS - Before the payment options accordion on the product detail page.
  * @property {"after_product_detail_payment_options"} AFTER_PRODUCT_DETAIL_PAYMENT_OPTIONS - After the payment options accordion on the product detail page.
- * @property {"before_product_detail_shipping_calculator"} BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR - Before the shipping calculator on the product detail page.
- * @property {"after_product_detail_shipping_calculator"} AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR - After the shipping calculator on the product detail page.
+ * @property {"before_product_detail_shipping_options"} BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS - Before the shipping options on the product detail page.
+ * @property {"after_product_detail_shipping_options"} AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS - After the shipping options on the product detail page.
  * @property {"before_cart_shipping_options"} BEFORE_CART_SHIPPING_OPTIONS - Before the shipping options on the cart page.
  * @property {"after_cart_shipping_options"} AFTER_CART_SHIPPING_OPTIONS - After the shipping options on the cart page.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
@@ -195,10 +195,10 @@ export const STOREFRONT_UI_SLOT = {
 	BEFORE_PRODUCT_DETAIL_PAYMENT_OPTIONS:
 		"before_product_detail_payment_options",
 	AFTER_PRODUCT_DETAIL_PAYMENT_OPTIONS: "after_product_detail_payment_options",
-	BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
-		"before_product_detail_shipping_calculator",
-	AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
-		"after_product_detail_shipping_calculator",
+	BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS:
+		"before_product_detail_shipping_options",
+	AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS:
+		"after_product_detail_shipping_options",
 	BEFORE_CART_SHIPPING_OPTIONS: "before_cart_shipping_options",
 	AFTER_CART_SHIPPING_OPTIONS: "after_cart_shipping_options",
 } as const;

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -133,12 +133,8 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_product_detail_payment_options"} AFTER_PRODUCT_DETAIL_PAYMENT_OPTIONS - After the payment options accordion on the product detail page.
  * @property {"before_product_detail_shipping_options"} BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS - Before the shipping options on the product detail page.
  * @property {"after_product_detail_shipping_options"} AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS - After the shipping options on the product detail page.
- * @property {"before_product_detail_shipping_calculator"} BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR - Before the shipping options on the product detail page. Deprecated; use BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS instead.
- * @property {"after_product_detail_shipping_calculator"} AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR - After the shipping options on the product detail page. Deprecated; use AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS instead.
  * @property {"before_cart_shipping_options"} BEFORE_CART_SHIPPING_OPTIONS - Before the shipping options on the cart page.
  * @property {"after_cart_shipping_options"} AFTER_CART_SHIPPING_OPTIONS - After the shipping options on the cart page.
- * @property {"before_cart_shipping_calculator"} BEFORE_CART_SHIPPING_CALCULATOR - Before the shipping options on the cart page. Deprecated; use BEFORE_CART_SHIPPING_OPTIONS instead.
- * @property {"after_cart_shipping_calculator"} AFTER_CART_SHIPPING_CALCULATOR - After the shipping options on the cart page. Deprecated; use AFTER_CART_SHIPPING_OPTIONS instead.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -203,18 +199,8 @@ export const STOREFRONT_UI_SLOT = {
 		"before_product_detail_shipping_options",
 	AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS:
 		"after_product_detail_shipping_options",
-	/** @deprecated Use BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS instead. */
-	BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
-		"before_product_detail_shipping_calculator",
-	/** @deprecated Use AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS instead. */
-	AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
-		"after_product_detail_shipping_calculator",
 	BEFORE_CART_SHIPPING_OPTIONS: "before_cart_shipping_options",
 	AFTER_CART_SHIPPING_OPTIONS: "after_cart_shipping_options",
-	/** @deprecated Use BEFORE_CART_SHIPPING_OPTIONS instead. */
-	BEFORE_CART_SHIPPING_CALCULATOR: "before_cart_shipping_calculator",
-	/** @deprecated Use AFTER_CART_SHIPPING_OPTIONS instead. */
-	AFTER_CART_SHIPPING_CALCULATOR: "after_cart_shipping_calculator",
 } as const;
 
 /**

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -133,8 +133,12 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_product_detail_payment_options"} AFTER_PRODUCT_DETAIL_PAYMENT_OPTIONS - After the payment options accordion on the product detail page.
  * @property {"before_product_detail_shipping_options"} BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS - Before the shipping options on the product detail page.
  * @property {"after_product_detail_shipping_options"} AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS - After the shipping options on the product detail page.
+ * @property {"before_product_detail_shipping_calculator"} BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR - Before the shipping options on the product detail page. Deprecated; use BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS instead.
+ * @property {"after_product_detail_shipping_calculator"} AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR - After the shipping options on the product detail page. Deprecated; use AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS instead.
  * @property {"before_cart_shipping_options"} BEFORE_CART_SHIPPING_OPTIONS - Before the shipping options on the cart page.
  * @property {"after_cart_shipping_options"} AFTER_CART_SHIPPING_OPTIONS - After the shipping options on the cart page.
+ * @property {"before_cart_shipping_calculator"} BEFORE_CART_SHIPPING_CALCULATOR - Before the shipping options on the cart page. Deprecated; use BEFORE_CART_SHIPPING_OPTIONS instead.
+ * @property {"after_cart_shipping_calculator"} AFTER_CART_SHIPPING_CALCULATOR - After the shipping options on the cart page. Deprecated; use AFTER_CART_SHIPPING_OPTIONS instead.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -199,8 +203,18 @@ export const STOREFRONT_UI_SLOT = {
 		"before_product_detail_shipping_options",
 	AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS:
 		"after_product_detail_shipping_options",
+	/** @deprecated Use BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS instead. */
+	BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
+		"before_product_detail_shipping_calculator",
+	/** @deprecated Use AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS instead. */
+	AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR:
+		"after_product_detail_shipping_calculator",
 	BEFORE_CART_SHIPPING_OPTIONS: "before_cart_shipping_options",
 	AFTER_CART_SHIPPING_OPTIONS: "after_cart_shipping_options",
+	/** @deprecated Use BEFORE_CART_SHIPPING_OPTIONS instead. */
+	BEFORE_CART_SHIPPING_CALCULATOR: "before_cart_shipping_calculator",
+	/** @deprecated Use AFTER_CART_SHIPPING_OPTIONS instead. */
+	AFTER_CART_SHIPPING_CALCULATOR: "after_cart_shipping_calculator",
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

- **Refactor**
  - Product detail shipping-related slot identifiers updated with new naming conventions to improve consistency and clarity across the UI slot system
    - `BEFORE_PRODUCT_DETAIL_SHIPPING_CALCULATOR` → `BEFORE_PRODUCT_DETAIL_SHIPPING_OPTIONS` (`"before_product_detail_shipping_calculator"` → `"before_product_detail_shipping_options"`)
    - `AFTER_PRODUCT_DETAIL_SHIPPING_CALCULATOR` → `AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS` (`"after_product_detail_shipping_calculator"` → `"after_product_detail_shipping_options"`)
- **Chores**
  - Package version updated to 0.64.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated shipping-related UI slot identifiers to use "shipping options" placements instead of the previous "shipping calculator" placements for product detail and cart pages.

* **Chores**
  * Package version bumped to 0.64.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->