### PR TITLE
feat: add new slots for registration form

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.64.0",
+	"version": "0.65.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -135,6 +135,8 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_product_detail_shipping_options"} AFTER_PRODUCT_DETAIL_SHIPPING_OPTIONS - After the shipping options on the product detail page.
  * @property {"before_cart_shipping_options"} BEFORE_CART_SHIPPING_OPTIONS - Before the shipping options on the cart page.
  * @property {"after_cart_shipping_options"} AFTER_CART_SHIPPING_OPTIONS - After the shipping options on the cart page.
+ * @property {"before_register_form"} BEFORE_REGISTER_FORM - Before the customer registration form on the storefront register page.
+ * @property {"after_register_form"} AFTER_REGISTER_FORM - After the customer registration form on the storefront register page.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -201,6 +203,8 @@ export const STOREFRONT_UI_SLOT = {
 		"after_product_detail_shipping_options",
 	BEFORE_CART_SHIPPING_OPTIONS: "before_cart_shipping_options",
 	AFTER_CART_SHIPPING_OPTIONS: "after_cart_shipping_options",
+	BEFORE_REGISTER_FORM: "before_register_form",
+	AFTER_REGISTER_FORM: "after_register_form",
 } as const;
 
 /**


### PR DESCRIPTION
Linear: [EXT-283](https://linear.app/nuvemshop-tiendanube/issue/EXT-283)

This PR adds two new storefront UI slots to wrap the customer registration form:
- `before_register_form`
- `after_register_form`

These enable apps to inject content (e.g. NubeSDK Field components for additional inputs, marketing copy, terms acceptance) immediately before or after the register form on the storefront.

It also bumps `@tiendanube/nube-sdk-types to 0.65.0` (minor — additive only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new UI slot placements for the customer registration form to enable before and after customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->