### PR TITLE
feat(types): add theme property to store type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9906,7 +9906,7 @@
       }
     },
     "packages/create-nube-app": {
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
@@ -10014,7 +10014,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.61.0",
+      "version": "0.66.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.65.0",
+	"version": "0.66.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -357,6 +357,9 @@ export type Store = {
 
 	/** Language code of the store (e.g., "en", "es"). */
 	language: LanguageKey;
+
+	/** The store's theme template (e.g., "recife", "morelia", "rio"). */
+	theme: string;
 };
 
 type FixedProductListSectionName =


### PR DESCRIPTION
## Description

This pull request introduces a minor update to the `Store` type definition by adding a new property to track the currently applied theme.

* Type definition update:
  * Added a `theme` property of type `string` to the `Store` type in `domain.ts` to represent the store's current theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store now requires an explicit theme setting so the UI consistently applies the chosen visual style.
* **Chores**
  * Package version bumped to reflect the updated public type contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->