### PR TITLE
fix(actions): replace non-existent 'Partner Request' label with 'Request'

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement for NubeSDK
 title: "[REQUEST] "
-labels: ["Partner Request"]
+labels: ["Request", "Partner"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/auto-label-request-type.yml
+++ b/.github/workflows/auto-label-request-type.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   auto-label:
     runs-on: ubuntu-latest
-    if: contains(github.event.issue.labels.*.name, 'Partner Request')
+    if: contains(github.event.issue.labels.*.name, 'Request')
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/sync-app-name-to-linear.yml
+++ b/.github/workflows/sync-app-name-to-linear.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   sync-title:
     runs-on: ubuntu-latest
-    if: contains(github.event.issue.labels.*.name, 'Partner Request')
+    if: contains(github.event.issue.labels.*.name, 'Request')
     steps:
       - uses: actions/github-script@v7
         env:


### PR DESCRIPTION
## Summary

- `feature-request.yml`: `labels: ["Partner Request"]` → `labels: ["Request", "Partner"]` — o label `Partner Request` nunca existiu no repo, então issues de feature request eram criadas sem nenhum label
- `auto-label-request-type.yml`: `if` condition atualizada para `Request`
- `sync-app-name-to-linear.yml`: `if` condition atualizada para `Request`

**Root cause:** `Partner Request` não existe como label. Os labels reais são `Request` e `Partner` separados.

## Test plan

- [ ] Abrir feature request com app name → labels `Request` e `Partner` aplicados automaticamente
- [ ] Label de tipo (`Slot`, `Component`, etc.) também aplicado pelo `auto-label-request-type`
- [ ] Título no GitHub e no Linear atualizado para `[App Name] Título`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal issue processing and labeling workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TiendaNube/nube-sdk/pull/276)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->