### PR TITLE
feat(actions): notify partners when Linear issue moves to Backlog

### DIFF
--- a/.github/workflows/notify-partner-on-backlog.yml
+++ b/.github/workflows/notify-partner-on-backlog.yml
@@ -1,0 +1,194 @@
+name: Notify Partner on Backlog
+
+on:
+  schedule:
+    - cron: '0 22 * * *'  # diário às 22:00 UTC (19h BRT, fim de expediente)
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+concurrency:
+  group: notify-partner-on-backlog
+  cancel-in-progress: false
+
+env:
+  # ISO 8601 — só notifica issues que transicionaram pra Backlog APÓS esta data.
+  # Atualize antes do merge para um timestamp imediatamente anterior ao deploy.
+  BACKLOG_CUTOFF: '2026-05-13T00:00:00Z'
+  TARGET_STATE_TYPE: 'backlog'
+  REQUIRED_FROM_STATE_TYPE: 'triage'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+        with:
+          script: |
+            const CUTOFF = new Date(process.env.BACKLOG_CUTOFF);
+            const TARGET_TYPE = process.env.TARGET_STATE_TYPE;
+            const FROM_TYPE = process.env.REQUIRED_FROM_STATE_TYPE;
+            const MARKER = '<!-- notify-partner-on-backlog -->';
+            const EXTERNAL_ASSOC = ['NONE', 'CONTRIBUTOR', 'FIRST_TIME_CONTRIBUTOR', 'FIRST_TIMER'];
+
+            if (!process.env.LINEAR_API_KEY || !process.env.LINEAR_TEAM_ID) {
+              core.setFailed('Missing LINEAR_API_KEY or LINEAR_TEAM_ID secret.');
+              return;
+            }
+            if (isNaN(CUTOFF.getTime())) {
+              core.setFailed(`Invalid BACKLOG_CUTOFF: "${process.env.BACKLOG_CUTOFF}"`);
+              return;
+            }
+
+            const query = `
+              query BacklogIssues($teamId: ID!, $targetType: String!) {
+                issues(
+                  filter: {
+                    team: { id: { eq: $teamId } }
+                    state: { type: { eq: $targetType } }
+                    attachments: { sourceType: { eq: "github" } }
+                  }
+                  first: 100
+                ) {
+                  nodes {
+                    id
+                    identifier
+                    title
+                    url
+                    history(first: 50) {
+                      nodes {
+                        createdAt
+                        fromState { name type }
+                        toState   { name type }
+                      }
+                    }
+                    attachments(first: 20) {
+                      nodes { url sourceType }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const linearRes = await fetch('https://api.linear.app/graphql', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': process.env.LINEAR_API_KEY,
+              },
+              body: JSON.stringify({
+                query,
+                variables: {
+                  teamId: process.env.LINEAR_TEAM_ID,
+                  targetType: TARGET_TYPE,
+                },
+              }),
+            });
+
+            if (!linearRes.ok) {
+              core.setFailed(`Linear API HTTP ${linearRes.status}: ${await linearRes.text()}`);
+              return;
+            }
+
+            const { data, errors } = await linearRes.json();
+            if (errors) {
+              core.setFailed(`Linear GraphQL errors: ${JSON.stringify(errors)}`);
+              return;
+            }
+
+            const issues = data?.issues?.nodes ?? [];
+            core.info(`Fetched ${issues.length} Linear backlog issues with GitHub attachments.`);
+
+            let notified = 0;
+            let skipped = 0;
+
+            for (const issue of issues) {
+              const transitions = (issue.history?.nodes ?? [])
+                .filter(h => h.toState?.type === TARGET_TYPE)
+                .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+              const lastTransition = transitions[0];
+
+              if (!lastTransition) {
+                core.info(`Skip ${issue.identifier}: no transition into target state found.`);
+                skipped++;
+                continue;
+              }
+              if (new Date(lastTransition.createdAt) < CUTOFF) {
+                core.info(`Skip ${issue.identifier}: transition predates cutoff (${lastTransition.createdAt}).`);
+                skipped++;
+                continue;
+              }
+              if (lastTransition.fromState?.type !== FROM_TYPE) {
+                core.info(`Skip ${issue.identifier}: fromState.type="${lastTransition.fromState?.type}" (expected "${FROM_TYPE}").`);
+                skipped++;
+                continue;
+              }
+
+              const ghAttachment = (issue.attachments?.nodes ?? []).find(a => a.sourceType === 'github');
+              if (!ghAttachment) {
+                core.info(`Skip ${issue.identifier}: no GitHub attachment.`);
+                skipped++;
+                continue;
+              }
+              const m = ghAttachment.url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/);
+              if (!m) {
+                core.info(`Skip ${issue.identifier}: attachment URL not an issue link (${ghAttachment.url}).`);
+                skipped++;
+                continue;
+              }
+              const [, owner, repo, num] = m;
+              const issue_number = Number(num);
+
+              let gh;
+              try {
+                ({ data: gh } = await github.rest.issues.get({ owner, repo, issue_number }));
+              } catch (err) {
+                core.warning(`Failed to fetch ${owner}/${repo}#${issue_number} for Linear ${issue.identifier}: ${err.message}`);
+                skipped++;
+                continue;
+              }
+
+              if (gh.state === 'closed') {
+                core.info(`Skip ${owner}/${repo}#${issue_number}: GH issue is closed.`);
+                skipped++;
+                continue;
+              }
+              if (gh.user?.type === 'Bot' || gh.user?.login.endsWith('[bot]')) {
+                core.info(`Skip ${owner}/${repo}#${issue_number}: author is a bot (${gh.user?.login}).`);
+                skipped++;
+                continue;
+              }
+              if (!EXTERNAL_ASSOC.includes(gh.author_association)) {
+                core.info(`Skip ${owner}/${repo}#${issue_number}: author_association="${gh.author_association}" not external.`);
+                skipped++;
+                continue;
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number, per_page: 100,
+              });
+              if (comments.some(c => c.body?.includes(MARKER))) {
+                core.info(`Skip ${owner}/${repo}#${issue_number}: marker already present.`);
+                skipped++;
+                continue;
+              }
+
+              const body = `${MARKER}
+              Hi @${gh.user.login},
+
+              Quick update. We've reviewed your request and moved it to our backlog. You'll get a comment here as soon as it ships.
+
+              Thanks for helping us improve the SDK.
+
+              — Extensibility Team`.replace(/^              /gm, '');
+
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info(`Notified ${owner}/${repo}#${issue_number} for Linear ${issue.identifier}.`);
+              notified++;
+            }
+
+            core.info(`Done. Notified: ${notified}. Skipped: ${skipped}.`);


### PR DESCRIPTION
## Summary

- Adds `notify-partner-on-backlog.yml` — scheduled daily workflow (22:00 UTC) that polls Linear once per day and comments on the originating GitHub issue when a Linear issue transitions **from Triage to Backlog**.
- Mirrors the disabled `notify-partner-on-close.yml` pattern (same guards, same idempotency marker style, same `actions/github-script@v7` approach).
- Reuses existing `LINEAR_API_KEY` and `LINEAR_TEAM_ID` secrets — no new secrets required.

## Why

When a partner files an issue in nube-sdk via GitHub, the team triages it in Linear. Today there's no automatic feedback to the partner when their issue gets prioritized to Backlog. This closes that loop: the partner gets a comment on their GH issue as soon as the team promotes Linear `Triage → Backlog`.

## Filters (all required)

- Linear `state.type == "backlog"` AND has GitHub attachment (`sourceType == "github"`).
- Most recent transition into Backlog came from `fromState.type == "triage"` (so re-priorizations like `In Progress → Backlog` do NOT trigger).
- Transition `createdAt` is after `BACKLOG_CUTOFF` env (no retroactive backfill).
- GH issue is open, author is external (`author_association` allowlist), not a bot.
- Marker `<!-- notify-partner-on-backlog -->` not already present in comments.

## Idempotency safeguards

- Marker check via paginated `listComments` (covers issues with >100 comments).
- `concurrency: notify-partner-on-backlog` group prevents overlapping runs from `workflow_dispatch` + scheduled trigger.
- Filter `fromState.type === "triage"` adds a second barrier on `Backlog → X → Backlog` cycles.

## Comment posted

```
<!-- notify-partner-on-backlog -->
Hi @{author},

Quick update. We've reviewed your request and moved it to our backlog. You'll get a comment here as soon as it ships.

Thanks for helping us improve the SDK.

— Extensibility Team
```

## Before merging

- [ ] Validate the Linear GraphQL query in [Linear's API explorer](https://linear.app/developers/graphql) — confirm `issues` filter accepts `attachments: { sourceType: { eq: "github" } }` at the top level. If not supported, switch to client-side filtering.
- [ ] Confirm via `query { workflowStates(filter: { team: { id: { eq: $teamId } } }) { nodes { name type } } }` that there's a state with `type=triage` AND one with `type=backlog`.
- [ ] Update `BACKLOG_CUTOFF` env (currently `2026-05-13T00:00:00Z`) to a timestamp immediately before merge so the first run only picks transitions that happen after deploy.

## Test plan

- [ ] **Happy path**: pick a Linear issue with GH attachment, ensure it's in Triage, move to Backlog. Trigger workflow manually via Actions → "Notify Partner on Backlog" → Run workflow. Confirm GH issue gets a comment with the marker.
- [ ] **Idempotency**: re-run manually right after — confirm no duplicate comment.
- [ ] **Negative: non-Triage source**: move a Linear issue from "In Progress" to "Backlog". Run manually → confirm skip in logs (`fromState.type` mismatch).
- [ ] **Negative: pre-cutoff**: pick an issue whose Triage→Backlog transition predates `BACKLOG_CUTOFF`. Run manually → confirm skip.
- [ ] **Negative: closed GH issue**: close a GH issue, then move its Linear counterpart to Backlog. Run manually → confirm skip.
- [ ] **Negative: internal author**: test with an issue opened by a team member (`author_association == MEMBER`). Run manually → confirm skip.
- [ ] Check Actions logs are clean (no warnings) and the `Notified N / Skipped M` summary line appears at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated notification workflow that posts daily backlog status updates to GitHub issues, configured with automatic scheduling at 22:00 UTC and manual trigger support. Includes intelligent duplicate detection and comprehensive error validation to ensure reliable notification delivery without redundancy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TiendaNube/nube-sdk/pull/280)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->