### PR TITLE
feat(events): add `product_variant:selected` event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10014,7 +10014,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.66.0",
+	"version": "0.67.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -78,7 +78,7 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {"location:updated"} LOCATION_UPDATED - Fired when the location is updated.
  * @property {"quickbuy:open"} QUICKBUY_OPEN - Fired when the quickbuy modal is opened.
  * @property {"quickbuy:close"} QUICKBUY_CLOSE - Fired when the quickbuy modal is closed.
- * @property {"product_variant:selected"} PRODUCT_VARIANT_SELECTED - Fired when a product variant is selected.
+ * @property {"product:variant_selected"} PRODUCT_VARIANT_SELECTED - Fired when a product variant is selected.
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
@@ -105,7 +105,7 @@ export const EVENT = {
 	LOCATION_UPDATED: "location:updated",
 	QUICKBUY_OPEN: "quickbuy:open",
 	QUICKBUY_CLOSE: "quickbuy:close",
-	PRODUCT_VARIANT_SELECTED: "product_variant:selected",
+	PRODUCT_VARIANT_SELECTED: "product:variant_selected",
 	...SENDABLE_EVENT,
 } as const;
 

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -78,6 +78,7 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {"location:updated"} LOCATION_UPDATED - Fired when the location is updated.
  * @property {"quickbuy:open"} QUICKBUY_OPEN - Fired when the quickbuy modal is opened.
  * @property {"quickbuy:close"} QUICKBUY_CLOSE - Fired when the quickbuy modal is closed.
+ * @property {"product_variant:selected"} PRODUCT_VARIANT_SELECTED - Fired when a product variant is selected.
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
@@ -104,6 +105,7 @@ export const EVENT = {
 	LOCATION_UPDATED: "location:updated",
 	QUICKBUY_OPEN: "quickbuy:open",
 	QUICKBUY_CLOSE: "quickbuy:close",
+	PRODUCT_VARIANT_SELECTED: "product_variant:selected",
 	...SENDABLE_EVENT,
 } as const;
 


### PR DESCRIPTION
This pull request adds a new event type to the `NubeSDKSendableEvent` system to support tracking when a product variant is selected. This enhances the event model for better handling of product-related interactions.

**Event system update:**

* Added a new event, `PRODUCT_VARIANT_SELECTED`, to the `NubeSDKSendableEvent` type documentation to represent when a product variant is selected.
* Registered the `PRODUCT_VARIANT_SELECTED` event in the `EVENT` constant, making it available throughout the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Event system extended to include a new "product:variant_selected" event for tracking variant selections across the SDK.
  * Public SDK typings updated so the new event is recognized by consumers.
  * Package version bumped to 0.67.0 to publish the updated event typings and make them available to integrators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TiendaNube/nube-sdk/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->