### PR TITLE
Ext 479/location adds

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.66.0",
+	"version": "0.67.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -523,6 +523,17 @@ export type AppLocation = {
 	 * value represents the value of that query parameter.
 	 */
 	queries: Record<string, string>;
+
+	/** 
+	* Equivalent to `document.title` on the storefront main thread,
+   	* captured by the SDK at the moment the location changed. */
+	title: string;
+
+	/** 
+	* Equivalent to `document.referrer`. The URL of the previous page in
+   	* the storefront SPA (or the external referrer for the landing page).
+   	* Null on the very first pageview when there is no referrer. */
+	previousUrl: string | null;
 };
 
 /**

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -533,7 +533,7 @@ export type AppLocation = {
 	* Equivalent to `document.referrer`. The URL of the previous page in
    	* the storefront SPA (or the external referrer for the landing page).
    	* Null on the very first pageview when there is no referrer. */
-	previousUrl: string | null;
+	referrer: string | null;
 };
 
 /**

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -524,15 +524,15 @@ export type AppLocation = {
 	 */
 	queries: Record<string, string>;
 
-	/** 
-	* Equivalent to `document.title` on the storefront main thread,
-   	* captured by the SDK at the moment the location changed. */
+	/**
+	 * Equivalent to `document.title` on the storefront main thread,
+	 * captured by the SDK at the moment the location changed. */
 	title: string;
 
-	/** 
-	* Equivalent to `document.referrer`. The URL of the previous page in
-   	* the storefront SPA (or the external referrer for the landing page).
-   	* Null on the very first pageview when there is no referrer. */
+	/**
+	 * Equivalent to `document.referrer`. The URL of the previous page in
+	 * the storefront SPA (or the external referrer for the landing page).
+	 * Null on the very first pageview when there is no referrer. */
 	referrer: string | null;
 };
 


### PR DESCRIPTION
## Descripción
Se agregan los campos `title` y `referrer` en `location`.

## Ticket de Linear
https://linear.app/nuvemshop-tiendanube/issue/EXT-479/titanpush-expose-page-title-and-previous-url-in-statelocation

## Pruebas
Se realizaron pruebas en staging y se evidenciaron en el siguiente documento
https://docs.google.com/document/d/1iNPZopnUz2NKSu3QR8eJwuDnti9ISO50NdeeREvA-us/edit?tab=t.0

## PRs relacionados
nube-sdk-internal -> https://github.com/TiendaNube/nube-sdk-internal/pull/207
checkout -> https://github.com/TiendaNube/services-checkout/pull/4821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added page title and referrer information to location tracking data.

* **Chores**
  * Package version updated to 0.67.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TiendaNube/nube-sdk/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->