### PR TITLE
Create floating edge slots

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.67.0",
+	"version": "0.68.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -15,6 +15,10 @@ import type { ObjectValues, Prettify } from "./utility";
  * @property {"corner_top_right"} CORNER_TOP_RIGHT - Top right corner of the page.
  * @property {"corner_bottom_left"} CORNER_BOTTOM_LEFT - Bottom left corner of the page.
  * @property {"corner_bottom_right"} CORNER_BOTTOM_RIGHT - Bottom right corner of the page.
+ * @property {"edge_top_center"} EDGE_TOP_CENTER - Top edge, horizontally centered.
+ * @property {"edge_bottom_center"} EDGE_BOTTOM_CENTER - Bottom edge, horizontally centered.
+ * @property {"edge_left_center"} EDGE_LEFT_CENTER - Left edge, vertically centered.
+ * @property {"edge_right_center"} EDGE_RIGHT_CENTER - Right edge, vertically centered.
  * @property {"before_line_items"} BEFORE_LINE_ITEMS - Before the list of items in the cart.
  * @property {"after_line_items"} AFTER_LINE_ITEMS - After the list of items in the cart.
  * @property {"after_header"} AFTER_HEADER - After the header.
@@ -29,6 +33,10 @@ export const COMMON_UI_SLOT = {
 	CORNER_TOP_RIGHT: "corner_top_right",
 	CORNER_BOTTOM_LEFT: "corner_bottom_left",
 	CORNER_BOTTOM_RIGHT: "corner_bottom_right",
+	EDGE_TOP_CENTER: "edge_top_center",
+	EDGE_BOTTOM_CENTER: "edge_bottom_center",
+	EDGE_LEFT_CENTER: "edge_left_center",
+	EDGE_RIGHT_CENTER: "edge_right_center",
 	BEFORE_LINE_ITEMS: "before_line_items",
 	AFTER_LINE_ITEMS: "after_line_items",
 	AFTER_HEADER: "after_header",


### PR DESCRIPTION
## Summary
- Add four edge slot positions to `COMMON_UI_SLOT` for floating UI placement: `EDGE_TOP_CENTER`, `EDGE_BOTTOM_CENTER`, `EDGE_LEFT_CENTER`, and `EDGE_RIGHT_CENTER`.
- These complement the existing `CORNER_*` slots, allowing apps to render floating elements centered along each edge of the page.
- Bump `@tiendanube/nube-sdk-types` to `0.68.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new edge-based UI positioning slot definitions: top center, bottom center, left center, and right center. These new slot definitions are now automatically integrated into and included across all supported UI slot configurations, derived sets, and platform interfaces, including checkout and storefront experiences.

* **Chores**
  * Package version bumped from 0.67.0 to 0.68.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TiendaNube/nube-sdk/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->