### PR TITLE
feat(slots): add new checkout UI slots for order number and summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10014,7 +10014,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.67.0",
+	"version": "0.68.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -57,6 +57,10 @@ export const COMMON_UI_SLOT = {
  * @property {"before_shipping_form"} BEFORE_SHIPPING_FORM - Before the shipping form in checkout.
  * @property {"after_shipping_form"} AFTER_SHIPPING_FORM - After the shipping form in checkout.
  * @property {"after_shipping_description"} AFTER_SHIPPING_DESCRIPTION - After the shipping description in checkout.
+ * @property {"before_order_number"} BEFORE_ORDER_NUMBER - Before the order number in checkout.
+ * @property {"after_order_number"} AFTER_ORDER_NUMBER - After the order number in checkout.
+ * @property {"before_order_summary"} BEFORE_ORDER_SUMMARY - Before the order summary in checkout.
+ * @property {"after_order_summary"} AFTER_ORDER_SUMMARY - After the order summary in checkout.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const CHECKOUT_UI_SLOT = {
@@ -73,6 +77,10 @@ export const CHECKOUT_UI_SLOT = {
 	BEFORE_SHIPPING_FORM: "before_shipping_form",
 	AFTER_SHIPPING_FORM: "after_shipping_form",
 	AFTER_SHIPPING_DESCRIPTION: "after_shipping_description",
+	BEFORE_ORDER_NUMBER: "before_order_number",
+	AFTER_ORDER_NUMBER: "after_order_number",
+	BEFORE_ORDER_SUMMARY: "before_order_summary",
+	AFTER_ORDER_SUMMARY: "after_order_summary",
 } as const;
 
 /**


### PR DESCRIPTION
This pull request adds new UI slot constants related to the checkout process, allowing for more granular placement of components around the order number and order summary sections.

New checkout UI slots:

* Added `BEFORE_ORDER_NUMBER` and `AFTER_ORDER_NUMBER` to allow components to be rendered before and after the order number in checkout (`CHECKOUT_UI_SLOT`, `slots.ts`). [[1]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR60-R63) [[2]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR80-R83)
* Added `BEFORE_ORDER_SUMMARY` and `AFTER_ORDER_SUMMARY` to allow components to be rendered before and after the order summary in checkout (`CHECKOUT_UI_SLOT`, `slots.ts`). [[1]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR60-R63) [[2]](diffhunk://#diff-d0a2904e0324b449bf635e997b472fd7acd8e27afaa18d2c83c8e91f50d15f1fR80-R83)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four new checkout UI customization slots: place custom content before/after the order number and before/after the order summary.
* **Chores**
  * Package version updated for the types library to reflect the new API additions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TiendaNube/nube-sdk/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->