### PR TITLE
Feat/ext 329 scroll to

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.70.0",
+	"version": "0.71.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/browser.ts
+++ b/packages/types/src/browser.ts
@@ -1,5 +1,5 @@
 import type { JsonObject, NubeComponent } from "./components";
-import type { AsyncNubeStorage } from "./storage";
+import type { AsyncNubeStorage, NubeScrollToEventData } from "./storage";
 
 /**
  * Represents the main interface for browser APIs that are usually not available in web workers.
@@ -51,4 +51,13 @@ export type NubeBrowserAPIs = {
 	 * @param form The `Form.Root` component to reset.
 	 */
 	resetForm: (form: NubeComponent) => void;
+
+	/**
+	* Scrolls the page to the given position.
+	 * @param options Scroll options compatible with the native ScrollToOptions interface.
+	 *   - top: Vertical scroll position in pixels.
+	 *   - left: Horizontal scroll position in pixels.
+	 *   - behavior: Scroll animation ("smooth", "auto", or "instant"). Defaults to "auto".
+	 */
+	scrollTo: (options?: NubeScrollToEventData) => void;
 };

--- a/packages/types/src/browser.ts
+++ b/packages/types/src/browser.ts
@@ -53,7 +53,7 @@ export type NubeBrowserAPIs = {
 	resetForm: (form: NubeComponent) => void;
 
 	/**
-	* Scrolls the page to the given position.
+	 * Scrolls the page to the given position.
 	 * @param options Scroll options compatible with the native ScrollToOptions interface.
 	 *   - top: Vertical scroll position in pixels.
 	 *   - left: Horizontal scroll position in pixels.

--- a/packages/types/src/internal.ts
+++ b/packages/types/src/internal.ts
@@ -2,6 +2,7 @@ import type {
 	NubeFormActionEventData,
 	NubeIframeMessageEventData,
 	NubeNavigateEventData,
+	NubeScrollToEventData,
 	NubeStorageEvent,
 	NubeStorageEventData,
 } from "./storage";
@@ -12,7 +13,8 @@ export type NubeSdkInternalEventData =
 	| NubeStorageEventData
 	| NubeNavigateEventData
 	| NubeIframeMessageEventData
-	| NubeFormActionEventData;
+	| NubeFormActionEventData
+	| NubeScrollToEventData;
 
 export const NubeSdkInternalEventPrefix = "internal:";
 

--- a/packages/types/src/storage.ts
+++ b/packages/types/src/storage.ts
@@ -10,7 +10,8 @@ export type NubeStorageEvent =
 	| "internal:navigate"
 	| "internal:iframe:message"
 	| "internal:form:submit"
-	| "internal:form:reset";
+	| "internal:form:reset"
+	| "internal:page:scroll_to";
 
 export type NubeStorageId = "local-storage" | "session-storage";
 
@@ -58,6 +59,12 @@ export type NubeStorageEventData =
 
 export type NubeNavigateEventData = {
 	route: `/${string}`;
+};
+
+export type NubeScrollToEventData = {
+	top?: number;
+	left?: number;
+	behavior?: "smooth" | "auto" | "instant";
 };
 
 export type NubeIframeMessageEventData = {


### PR DESCRIPTION
Linear: [EXT-329](https://linear.app/nuvemshop-tiendanube/issue/EXT-329/abejita-scroll-to-top-event)

## What
Adds public types for the scroll-to browser API (`nube.getBrowserAPIs().scrollTo()`):
- `NubeScrollToEventData` + `internal:page:scroll_to` event
- `scrollTo` on `NubeBrowserAPIs`
- bump `@tiendanube/nube-sdk-types` 0.70.0 → 0.71.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added programmatic page scrolling to the browser API, with optional target coordinates and selectable behavior (smooth, auto, instant); includes support for emitting/handling corresponding scroll events.

* **Chores**
  * Bumped package version to 0.71.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->