### PR TITLE
feat(store): add currency formatting properties to Store type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10014,7 +10014,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.72.0",
+      "version": "0.73.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.72.0",
+	"version": "0.73.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -376,7 +376,7 @@ export type Store = {
 	/**
 	 * Currency code used in the store (e.g., "USD", "EUR").
 	 *
-	 * @deprecated Use {@link Store.currency_details} instead, which exposes the
+	 * @deprecated Use {@link Store.currency_details.code} instead, which exposes the
 	 * currency code along with its formatting rules.
 	 */
 	currency: string;

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -340,26 +340,12 @@ export type Order = {
 };
 
 /**
- * Represents information about the current store.
+ * Represents the currency used by a store, including its code and the
+ * formatting rules used to display monetary values.
  */
-export type Store = {
-	/** Unique identifier for the store. */
-	id: number;
-
-	/** Name of the store. */
-	name: string;
-
-	/** Domain name associated with the store. */
-	domain: string;
-
-	/** Currency code used in the store (e.g., "USD", "EUR"). */
-	currency: string;
-
-	/** Language code of the store (e.g., "en", "es"). */
-	language: LanguageKey;
-
-	/** The store's theme template (e.g., "recife", "morelia", "rio"). */
-	theme: string;
+export type CurrencyDetails = {
+	/** Currency code used in the store (e.g., "USD", "EUR", "BRL"). */
+	code: string;
 
 	/** Character used to separate the decimal part of a value (e.g., ","). */
 	cents_separator: string;
@@ -372,6 +358,37 @@ export type Store = {
 
 	/** Short form of the currency symbol (e.g., "R$"). */
 	display_short: string;
+};
+
+/**
+ * Represents information about the current store.
+ */
+export type Store = {
+	/** Unique identifier for the store. */
+	id: number;
+
+	/** Name of the store. */
+	name: string;
+
+	/** Domain name associated with the store. */
+	domain: string;
+
+	/**
+	 * Currency code used in the store (e.g., "USD", "EUR").
+	 *
+	 * @deprecated Use {@link Store.currency_details} instead, which exposes the
+	 * currency code along with its formatting rules.
+	 */
+	currency: string;
+
+	/** Currency used by the store, including its formatting rules. */
+	currency_details: CurrencyDetails;
+
+	/** Language code of the store (e.g., "en", "es"). */
+	language: LanguageKey;
+
+	/** The store's theme template (e.g., "recife", "morelia", "rio"). */
+	theme: string;
 };
 
 type FixedProductListSectionName =

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -360,6 +360,18 @@ export type Store = {
 
 	/** The store's theme template (e.g., "recife", "morelia", "rio"). */
 	theme: string;
+
+	/** Character used to separate the decimal part of a value (e.g., ","). */
+	cents_separator: string;
+
+	/** Character used to separate thousands in a value (e.g., "."). */
+	thousands_separator: string;
+
+	/** Long form of the currency symbol (e.g., "R$"). */
+	display_long: string;
+
+	/** Short form of the currency symbol (e.g., "R$"). */
+	display_short: string;
 };
 
 type FixedProductListSectionName =


### PR DESCRIPTION
## What

Adds currency formatting properties to the `Store` type in `packages/types/src/domain.ts`:

- `cents_separator` — character used to separate the decimal part of a value (e.g., `","`)
- `thousands_separator` — character used to separate thousands in a value (e.g., `"."`)
- `display_long` — long form of the currency symbol (e.g., `"R$"`)
- `display_short` — short form of the currency symbol (e.g., `"R$"`)

## Why

These properties expose the store's currency display configuration to consumers of the SDK, enabling correct price formatting based on the store's locale settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stores now include structured currency details (currency code, decimal/thousands separators, and long/short display options) for more accurate and flexible currency formatting across the product.

* **Chores**
  * The legacy single-currency field has been marked deprecated; callers are guided to use the new structured currency details going forward to ensure consistent formatting and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->