### PR TITLE
feat(adapters): add Form.Radio component

### DIFF
--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-jsx",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Library for building JSX interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jsx/src/components.tsx
+++ b/packages/jsx/src/components.tsx
@@ -43,6 +43,8 @@ import type {
 	NubeComponentFormFieldError,
 	NubeComponentFormFieldErrorProps,
 	NubeComponentFormFieldProps,
+	NubeComponentFormRadio,
+	NubeComponentFormRadioProps,
 	NubeComponentFormResetter,
 	NubeComponentFormResetterProps,
 	NubeComponentFormRoot,
@@ -140,6 +142,7 @@ import {
 	formFailure,
 	formField,
 	formFieldError,
+	formRadio,
 	formResetter,
 	formRoot,
 	formSelect,
@@ -1082,11 +1085,28 @@ function FormCheckbox(
 }
 
 /**
+ * Creates a `Form.Radio` component.
+ *
+ * Radio-group bound to the surrounding `Form.Root`. Renders a list of radio
+ * inputs sharing the same `name` and mirrors the `Form.Select` API shape
+ * (a list of `{ label, value }` options + an optional default `value`).
+ * Adds Form-driven validation: pristine→valid/invalid on blur,
+ * force-validated on submit, `valueMissing` surfaced through
+ * `Form.FieldError match="valueMissing"`.
+ *
+ * @param props - The properties for configuring the form radio component.
+ * @returns A `NubeComponentFormRadio` object representing the radio group.
+ */
+function FormRadio(props: NubeComponentFormRadioProps): NubeComponentFormRadio {
+	return formRadio(props);
+}
+
+/**
  * Creates a `Form.Resetter` component.
  *
  * `Form.Resetter` is equivalent to `<button type="reset">` and clears every
- * descendant `Form.Field` / `Form.Select` / `Form.Checkbox` back to its
- * initial value. The browser fires the form's native `reset` event, which
+ * descendant `Form.Field` / `Form.Select` / `Form.Checkbox` / `Form.Radio`
+ * back to its initial value. The browser fires the form's native `reset` event, which
  * the surrounding `Form.Root` listens to in order to also restore each
  * field's React-controlled validity state to `"pristine"`. No worker
  * round-trip is involved.
@@ -1154,6 +1174,7 @@ export const Form = {
 	FieldError: FormFieldError,
 	Select: FormSelect,
 	Checkbox: FormCheckbox,
+	Radio: FormRadio,
 	Resetter: FormResetter,
 	Submitter: FormSubmitter,
 	Success: FormSuccess,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.74.0",
+	"version": "0.75.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -896,6 +896,24 @@ export type NubeComponentFormRootEventHandler = NubeComponentEventHandler<
 export type NubeFormData = Record<string, string>;
 
 /**
+ * Convenience alias for the parameter passed to `formRoot.onChange`.
+ * Equivalent to `Parameters<NubeComponentFormRootEventHandler>[0]` narrowed
+ * to the `"change"` event. The `value` field is the JSON-stringified
+ * {@link NubeFormData} snapshot of the form; parse it when you need
+ * structured access:
+ *
+ *     onChange: (event: NubeFormChangeEvent) => {
+ *       const data = JSON.parse(event.value ?? "{}") as NubeFormData;
+ *       // …
+ *     }
+ */
+export type NubeFormChangeEvent = {
+	type: "change";
+	state: NubeSDKState;
+	value?: string;
+};
+
+/**
  * Represents the properties available for a `formRoot` component.
  *
  * `formRoot` declares a native HTML form whose submission is handled on the
@@ -1045,6 +1063,45 @@ export type NubeComponentFormSelectProps = Prettify<
  */
 export type NubeComponentFormSelect = Prettify<
 	NubeComponentBase & NubeComponentFormSelectProps & { type: "formSelect" }
+>;
+
+/**
+ * Represents the properties available for a `formRadio` component.
+ *
+ * Radio-group counterpart of `formField`. Renders a group of radio inputs
+ * sharing the same `name` and adds Form-driven validation. `valueMissing`
+ * is the only failing key produced by default (when `required` and no
+ * option is selected).
+ */
+export type NubeComponentFormRadioProps = Prettify<
+	NubeComponentBase &
+		ChildrenProps & {
+			/** Field name as it appears in the submitted `FormData`. */
+			name: string;
+			/** Group label rendered above the options. */
+			label: string;
+			/** Selectable options (mirrors `select.options`). */
+			options: { label: string; value: string }[];
+			/** Default selected value. */
+			value?: string;
+			required?: boolean;
+			disabled?: boolean;
+			/** Style slots mirroring the group, label and individual options. */
+			style?: {
+				container?: NubeComponentStyle;
+				label?: NubeComponentStyle;
+				option?: NubeComponentStyle;
+				radio?: NubeComponentStyle;
+			};
+		}
+>;
+
+/**
+ * Represents a `formRadio` component, used for radio-group inputs inside a
+ * `formRoot`.
+ */
+export type NubeComponentFormRadio = Prettify<
+	NubeComponentBase & NubeComponentFormRadioProps & { type: "formRadio" }
 >;
 
 /**
@@ -2411,6 +2468,7 @@ export type NubeComponent =
 	| NubeComponentFormFieldError
 	| NubeComponentFormSelect
 	| NubeComponentFormCheckbox
+	| NubeComponentFormRadio
 	| NubeComponentFormResetter
 	| NubeComponentFormSubmitter
 	| NubeComponentFormSuccess
@@ -2452,6 +2510,7 @@ export type NubeComponentWithChildren =
 	| NubeComponentFormFieldError
 	| NubeComponentFormSelect
 	| NubeComponentFormCheckbox
+	| NubeComponentFormRadio
 	| NubeComponentFormResetter
 	| NubeComponentFormSubmitter
 	| NubeComponentFormSuccess

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-ui",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Library for building declarative interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/src/components/form-radio.ts
+++ b/packages/ui/src/components/form-radio.ts
@@ -1,0 +1,25 @@
+import type {
+	NubeComponentFormRadio,
+	NubeComponentFormRadioProps,
+} from "@tiendanube/nube-sdk-types";
+import { generateInternalId } from "./generateInternalId";
+
+/**
+ * Creates a `formRadio` component.
+ *
+ * A `formRadio` renders a group of radio inputs bound to the surrounding
+ * `formRoot`. It mirrors the public `select` props shape (a list of
+ * `{ label, value }` options + an optional default `value`) but renders as
+ * a radio group and adds Form-driven validation (`required` is mapped to
+ * the native `valueMissing` validity key when no option is selected).
+ *
+ * @param props - The properties for configuring the formRadio component.
+ * @returns A `NubeComponentFormRadio` object representing the radio group.
+ */
+export const formRadio = (
+	props: NubeComponentFormRadioProps,
+): NubeComponentFormRadio => ({
+	type: "formRadio",
+	...props,
+	__internalId: generateInternalId("formRadio", props),
+});

--- a/packages/ui/src/components/form.spec.ts
+++ b/packages/ui/src/components/form.spec.ts
@@ -3,6 +3,7 @@ import { formCheckbox } from "./form-checkbox";
 import { formFailure } from "./form-failure";
 import { formField } from "./form-field";
 import { formFieldError } from "./form-field-error";
+import { formRadio } from "./form-radio";
 import { formResetter } from "./form-resetter";
 import { formRoot } from "./form-root";
 import { formSelect } from "./form-select";
@@ -160,6 +161,46 @@ describe("formSelect", () => {
 			options: [{ label: "A", value: "a" }],
 		});
 		const b = formSelect({
+			name: "x",
+			label: "X",
+			options: [{ label: "B", value: "b" }],
+		});
+
+		expect(a.__internalId).not.toBe(b.__internalId);
+	});
+});
+
+describe("formRadio", () => {
+	it("creates a formRadio with required props preserved", () => {
+		const options = [
+			{ label: "Daily", value: "daily" },
+			{ label: "Weekly", value: "weekly" },
+		];
+
+		const node = formRadio({
+			name: "frequency",
+			label: "Frequency",
+			options,
+			required: true,
+			value: "daily",
+		});
+
+		expect(node.type).toBe("formRadio");
+		expect(node.name).toBe("frequency");
+		expect(node.label).toBe("Frequency");
+		expect(node.options).toBe(options);
+		expect(node.required).toBe(true);
+		expect(node.value).toBe("daily");
+		expect(node.__internalId).toMatch(/^formRadio-test-app-id-[a-z0-9]+$/);
+	});
+
+	it("produces different ids for radios with different options", () => {
+		const a = formRadio({
+			name: "x",
+			label: "X",
+			options: [{ label: "A", value: "a" }],
+		});
+		const b = formRadio({
 			name: "x",
 			label: "X",
 			options: [{ label: "B", value: "b" }],

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -56,6 +56,7 @@ export * from "./components/form-field";
 export * from "./components/form-field-error";
 export * from "./components/form-select";
 export * from "./components/form-checkbox";
+export * from "./components/form-radio";
 export * from "./components/form-resetter";
 export * from "./components/form-submitter";
 export * from "./components/form-success";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `Form.Radio` component for radio group form controls with validation and styling options

* **Documentation**
  * Updated `Form.Resetter` documentation to clarify that form reset now restores descendant radio controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->