### PR TITLE
feat(slots): add new registration form field slots to storefront UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10186,7 +10186,7 @@
     },
     "packages/jsx": {
       "name": "@tiendanube/nube-sdk-jsx",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10425,7 +10425,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.74.0",
+      "version": "0.76.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"
@@ -10437,7 +10437,7 @@
     },
     "packages/ui": {
       "name": "@tiendanube/nube-sdk-ui",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.75.0",
+	"version": "0.76.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -157,6 +157,10 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_cart_shipping_options"} AFTER_CART_SHIPPING_OPTIONS - After the shipping options on the cart page.
  * @property {"before_register_form"} BEFORE_REGISTER_FORM - Before the customer registration form on the storefront register page.
  * @property {"after_register_form"} AFTER_REGISTER_FORM - After the customer registration form on the storefront register page.
+ * @property {"before_register_form_fields"} BEFORE_REGISTER_FORM_FIELDS - Before the fields of the customer registration form on the storefront register page.
+ * @property {"after_register_form_fields"} AFTER_REGISTER_FORM_FIELDS - After the fields of the customer registration form on the storefront register page.
+ * @property {"before_register_form_submit"} BEFORE_REGISTER_FORM_SUBMIT - Before the submit button of the customer registration form on the storefront register page.
+ * @property {"after_register_form_submit"} AFTER_REGISTER_FORM_SUBMIT - After the submit button of the customer registration form on the storefront register page.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -229,6 +233,10 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_CART_SHIPPING_OPTIONS: "after_cart_shipping_options",
 	BEFORE_REGISTER_FORM: "before_register_form",
 	AFTER_REGISTER_FORM: "after_register_form",
+	BEFORE_REGISTER_FORM_FIELDS: "before_register_form_fields",
+	AFTER_REGISTER_FORM_FIELDS: "after_register_form_fields",
+	BEFORE_REGISTER_FORM_SUBMIT: "before_register_form_submit",
+	AFTER_REGISTER_FORM_SUBMIT: "after_register_form_submit",
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Adds four new storefront UI slots for the customer registration form, giving extensions more granular insertion points within the register page:

- `before_register_form_fields` — before the fields of the registration form
- `after_register_form_fields` — after the fields of the registration form
- `before_register_form_submit` — before the submit button
- `after_register_form_submit` — after the submit button

Bumps `@tiendanube/nube-sdk-types` to `0.76.0`.

## Changes

- Add the four slot constants to `STOREFRONT_UI_SLOT` in [packages/types/src/slots.ts](packages/types/src/slots.ts) with corresponding JSDoc.
- Bump version in [packages/types/package.json](packages/types/package.json).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new customization points for registration forms, enabling placement of content before and after form fields and the submission button.

* **Chores**
  * Bumped the package version to 0.76.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->