### PR TITLE
feat(types): add showCopyButton prop to Text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10842,7 +10842,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.77.0",
+      "version": "0.78.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/doc/docs/components/text.md
+++ b/packages/doc/docs/components/text.md
@@ -38,6 +38,15 @@ text({
 | heading    | 1\|2\|3\|4\|5\|6             | No       | The heading level (h1-h6).                                              |
 | modifiers  | TxtModifier[]                | No       | Array of text formatting modifiers.                                     |
 | inline     | boolean                      | No       | Whether the text should be displayed inline.                            |
+| showCopyButton | boolean                  | No       | Renders a copy button that copies the text content to the clipboard.    |
+
+### Styling the copy button
+
+When `showCopyButton` is enabled, the copy icon exposes a `data-clipboard-state`
+attribute that reflects its state, so it can be styled per state via CSS:
+
+- `data-clipboard-state="idle"` — default (copy icon).
+- `data-clipboard-state="copied"` — right after a successful copy (check icon).
 
 ### Property values
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.77.0",
+	"version": "0.78.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -748,6 +748,11 @@ export type NubeComponentTextProps = Prettify<
 		inline?: boolean;
 		style?: NubeComponentStyle;
 		children?: NubeComponentChildren;
+		/**
+		 * When `true`, renders a copy button that copies the text content to the
+		 * clipboard.
+		 */
+		showCopyButton?: boolean;
 	}
 >;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `showCopyButton` property to the Text component. When enabled, it renders a copy button that copies the text to the clipboard, including styling hooks for the copy icon’s states (idle and copied).

* **Documentation**
  * Updated Text component documentation with details on the new `showCopyButton` option and how to style the copy button based on its state. 

* **Chores**
  * Bumped the types package version to `0.78.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->