### PR TITLE
feat(events): add account:register sendable event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10842,7 +10842,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.76.0",
+      "version": "0.77.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.76.0",
+	"version": "0.77.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -740,19 +740,30 @@ export type BillingAddress = Prettify<
 >;
 
 /**
+ * Represents the contact information of a customer in the checkout process.
+ */
+export type CustomerContact = {
+	email: Nullable<string>;
+	name: Nullable<string>;
+	phone: Nullable<string>;
+	accepts_marketing: Nullable<boolean>;
+	accepts_marketing_updated_at: Nullable<string>;
+};
+
+/**
  * Represents a customer in the checkout process.
  */
 export type Customer = {
-	id: Nullable<number>;
-	contact: {
-		email: Nullable<string>;
-		name: Nullable<string>;
-		phone: Nullable<string>;
-		accepts_marketing: Nullable<boolean>;
-		accepts_marketing_updated_at: Nullable<string>;
-	};
-	shipping_address: ShippingAddress;
-	billing_address: BillingAddress;
+	id?: Nullable<number>;
+	contact?: Nullable<CustomerContact>;
+	shipping_address?: Nullable<ShippingAddress>;
+	billing_address?: Nullable<BillingAddress>;
+	name?: Nullable<string>;
+	email?: Nullable<string>;
+	phone?: Nullable<string>;
+	cpf_cnpj?: Nullable<string>;
+	business_name?: Nullable<string>;
+	billing_country?: Nullable<string>;
 };
 
 /**

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -24,6 +24,7 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  * @property {"coupon:remove"} COUPON_REMOVE - Used to remove a coupon from the cart.
  * @property {"shipping:select"} SHIPPING_SELECT - Used to select shipping option.
  * @property {"order:add:extra"} ORDER_ADD_EXTRA - Used to add additional metadata to an order.
+ * @property {"account:register"} ACCOUNT_REGISTER - Used to autocomplete the signup form in the storefront.
  */
 export const SENDABLE_EVENT = {
 	CART_VALIDATE: "cart:validate",
@@ -37,6 +38,7 @@ export const SENDABLE_EVENT = {
 	COUPON_ADD: "coupon:add",
 	COUPON_REMOVE: "coupon:remove",
 	SHIPPING_SELECT: "shipping:select",
+	ACCOUNT_REGISTER: "account:register",
 } as const;
 
 /**


### PR DESCRIPTION
## Description

Adds a new `account:register` sendable event to the SDK's event types.

This event allows apps to autocomplete the signup form in the storefront, following the same pattern as the other entries in `SENDABLE_EVENT`.

## Example

```js
nube.send("account:register", () => ({
	customer: {
		name: "John Doe",
		email: "john.doe@example.com",
		cpf_cnpj: "123.456.789-00",
		phone: "81999999999",
	},
}));
```

## Changes

- Add `ACCOUNT_REGISTER: "account:register"` to the `SENDABLE_EVENT` constant in [packages/types/src/events.ts](packages/types/src/events.ts).
- Document the new event in the `SENDABLE_EVENT` JSDoc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for the `account:register` SDK sendable event to improve tracking of account registration activity.

* **API Changes**
  * Updated checkout `Customer` typing to support optional and nullable customer/contact fields for greater flexibility.
  * Introduced a `CustomerContact` type to represent checkout contact details.

* **Chores**
  * Bumped the `types` package version to `0.77.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->