### PR TITLE
feat(types): add api namespace with Checkout adapter

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.76.0",
+	"version": "0.77.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,0 +1,19 @@
+import type { CheckoutCommands } from "./checkout";
+
+/**
+ * Host-API namespace exposed on `NubeSDK` as `nube.api`.
+ *
+ * Groups typed adapters that let an app invoke host-side capabilities
+ * across the worker / main thread boundary. Each adapter is materialized
+ * lazily on first access and cached for the lifetime of the worker.
+ *
+ * Future integrations (analytics, marketing, etc.) extend this namespace
+ * with additional `get*()` factories.
+ */
+export type NubeAPI = {
+	/**
+	 * Returns the checkout adapter. Subsequent calls return the same
+	 * instance — identity comparisons (`===`) hold.
+	 */
+	getCheckout(): CheckoutCommands;
+};

--- a/packages/types/src/checkout.ts
+++ b/packages/types/src/checkout.ts
@@ -1,0 +1,72 @@
+/**
+ * Args for `changePaymentBenefit`. `value` is the benefit label rendered
+ * under the gateway (e.g. "12x sem juros").
+ */
+export type PaymentBenefit = {
+	id: string;
+	value: string;
+};
+
+/**
+ * Args for `addPaymentContentText`. `value` is the plain-text content to
+ * render under the gateway. Host only honors this for external gateways.
+ */
+export type PaymentContent = {
+	id: string;
+	value: string;
+};
+
+/**
+ * Args for `hideInstallments`. `value` is the list of installment counts to
+ * hide for the gateway (e.g. `[3, 6]` hides 3x and 6x options, keeping the
+ * rest visible). Host only honors this for transparent credit/debit card
+ * gateways.
+ */
+export type InstallmentsToHide = {
+	id: string;
+	value: number[];
+};
+
+/**
+ * Worker-facing adapter for checkout host operations.
+ *
+ * Each method mirrors the host's public surface 1:1. All methods cross the
+ * worker / main thread boundary via the internal command channel and return
+ * Promises. Errors arrive as standard `Error` instances with messages in
+ * the form `"<code>: <message>"`, where `<code>` is one of
+ * `unknown_command`, `command_failed`, or `timeout`.
+ */
+export type CheckoutCommands = {
+	/**
+	 * Logs the IDs of every payment gateway currently enabled in the
+	 * checkout to the host console. Does **not** return the list — the
+	 * host method is fire-and-forget and intended for debugging.
+	 */
+	getPaymentIds(): Promise<void>;
+
+	/**
+	 * Hides one or more payment options.
+	 *
+	 * @param gatewayIds — Array of gateway IDs to hide.
+	 */
+	hidePaymentOptions(gatewayIds: string[]): Promise<void>;
+
+	/**
+	 * Changes the benefit (label rendered under the option) for a payment
+	 * gateway.
+	 */
+	changePaymentBenefit(benefit: PaymentBenefit): Promise<void>;
+
+	/**
+	 * Adds descriptive content under a payment option. Host only honors
+	 * this for external gateways.
+	 */
+	addPaymentContentText(content: PaymentContent): Promise<void>;
+
+	/**
+	 * Hides specific installment counts for a payment gateway, keeping the
+	 * gateway itself (and other installment counts) visible. Host only
+	 * honors this for transparent credit/debit card gateways.
+	 */
+	hideInstallments(installments: InstallmentsToHide): Promise<void>;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,8 @@
 // Type exports
+export type * from "./api";
 export type * from "./browser";
 export type * from "./app-settings";
+export type * from "./checkout";
 export type * from "./main";
 export type * from "./domain";
 export type * from "./utility";

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -1,3 +1,4 @@
+import type { NubeAPI } from "./api";
 import type { AppSettingsValues } from "./app-settings";
 import type { NubeBrowserAPIs } from "./browser";
 import type { NubeComponent, UI } from "./components";
@@ -249,6 +250,13 @@ export type NubeSDK = {
 	 * @returns The app settings values, or an empty object if not available.
 	 */
 	getAppSettings(): AppSettingsValues;
+
+	/**
+	 * Host-API namespace. Exposes typed adapters that invoke host-side
+	 * capabilities across the worker / main thread boundary
+	 * (e.g. `nube.api.getCheckout()`).
+	 */
+	api: NubeAPI;
 };
 
 /**


### PR DESCRIPTION
Apps can now invoke checkout host operations through `nube.api.getCheckout()`, which exposes typed async methods: getPaymentIds, hidePaymentOptions, changePaymentBenefit, addPaymentContentText, hideInstallments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Host-API namespace with checkout management capabilities: retrieve payment gateway IDs, control payment option visibility, configure payment benefits, add external payment content, and customize installment options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->