### PR TITLE
feat(types): remove unused fields from ProductVariant type

### DIFF
--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -165,14 +165,10 @@ export type ProductImage = {
 export type ProductVariant = {
 	/** Unique identifier for the variant. */
 	id: number;
-	/** Target age group for the product variant. */
-	age_group: "adult" | "infant" | "kids" | "newborn" | "toddler" | null;
 	/** Barcode identifier for the variant. */
 	barcode: null | string;
 	/** Original price before any discounts. */
 	compare_at_price: null | string;
-	/** Cost of the product for the merchant. */
-	cost: null | number;
 	/** Custom data associated with the variant. */
 	customData?: {
 		/** Color information for the variant. */
@@ -180,23 +176,8 @@ export type ProductVariant = {
 	};
 	/** Depth measurement of the product. */
 	depth: string;
-	/** Target gender for the product variant. */
-	gender: "female" | "male" | "unisex" | null;
 	/** Height measurement of the product. */
 	height: string;
-	/** ID of the associated image for this variant. */
-	image_id: null | number;
-	/** Inventory levels across different locations. */
-	inventory_levels: {
-		/** Unique identifier for the inventory level. */
-		id: number;
-		/** Location identifier where the stock is held. */
-		location_id: string;
-		/** Available stock quantity at this location. */
-		stock: null | number;
-		/** ID of the variant this inventory refers to. */
-		variant_id: number;
-	}[];
 	/** Manufacturer Part Number. */
 	mpn: null | number;
 	/** Position of this variant in the product's variant list. */
@@ -205,8 +186,6 @@ export type ProductVariant = {
 	price: null | string;
 	/** ID of the parent product. */
 	product_id: number;
-	/** Promotional or discounted price. */
-	promotional_price: null | string;
 	/** Stock Keeping Unit identifier. */
 	sku: null | string;
 	/** Total available stock for this variant. */

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -176,6 +176,8 @@ export type ProductVariant = {
 	};
 	/** Depth measurement of the product. */
 	depth: string;
+	/** Whether the variant has a promotional price. */
+	has_promotional_price: boolean;
 	/** Height measurement of the product. */
 	height: string;
 	/** Manufacturer Part Number. */

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -190,6 +190,11 @@ export type ProductVariant = {
 	price: null | string;
 	/** ID of the parent product. */
 	product_id: number;
+	/**
+	 * Promotional or discounted price.
+	 * @deprecated Use `has_promotional_price` together with `price` or `compare_at_price` instead.
+	 */
+	promotional_price: null | string;
 	/** Stock Keeping Unit identifier. */
 	sku: null | string;
 	/** Total available stock for this variant. */

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -178,6 +178,8 @@ export type ProductVariant = {
 	depth: string;
 	/** Whether the variant has a promotional price. */
 	has_promotional_price: boolean;
+	/** ID of the associated image for this variant. */
+	image_id: null | number;
 	/** Height measurement of the product. */
 	height: string;
 	/** Manufacturer Part Number. */


### PR DESCRIPTION
Removes fields from the `ProductVariant` type that are not exposed to the storefront/app context:

- `age_group`
- `cost`
- `gender`
- `image_id`
- `inventory_levels`
- `promotional_price`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified product variant data returned by the platform by removing several less-used fields (such as targeting attributes, merchant cost, and per-location inventory).
  * Streamlined promotional pricing: variants now provide a boolean flag (`has_promotional_price`) instead of a promotional price amount.
  * Variant details now emphasize core information such as barcode, compare-at pricing, custom data, and dimensions (including the existing `image_id` field).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->