### PR TITLE
fix(helper): deduplicate onEvent listener registration to prevent double-firing

### DIFF
--- a/packages/helper/src/lib/events.spec.ts
+++ b/packages/helper/src/lib/events.spec.ts
@@ -32,6 +32,19 @@ describe("events", () => {
 
 			expect(sdk.off).toHaveBeenCalledWith("cart:update", listener);
 		});
+
+		it("deduplicates: removes before re-adding when the same listener is registered twice", () => {
+			const listener = vi.fn();
+
+			onEvent("cart:update", listener);
+			onEvent("cart:update", listener);
+
+			// Each call removes before adding, so off is called twice and on is called twice,
+			// but the net effect is a single active registration (not two stacked ones).
+			expect(sdk.off).toHaveBeenCalledTimes(2);
+			expect(sdk.on).toHaveBeenCalledTimes(2);
+			expect(sdk.off).toHaveBeenCalledWith("cart:update", listener);
+		});
 	});
 
 	describe("toastOn", () => {

--- a/packages/helper/src/lib/events.ts
+++ b/packages/helper/src/lib/events.ts
@@ -42,6 +42,9 @@ export function onEvent<T extends NubeSDKListenableEvent>(
 	listener: EventListenerMap[T],
 ): () => void {
 	const nube = getNubeInstance();
+	// Guard against duplicate registration (e.g. after SPA navigation):
+	// remove first so the same listener is never attached more than once.
+	nube.off(event, listener);
 	nube.on(event, listener);
 	return () => nube.off(event, listener);
 }


### PR DESCRIPTION
Fixes a double-firing issue when the same listener is registered more than once for the same event — most commonly after SPA navigation, where a page re-mounts without a full reload and calls `onEvent` again before the previous subscription is cleaned up.

**Root cause:** `onEvent` called `nube.on` unconditionally, so two calls with the same function reference stacked two active subscriptions, causing the callback to fire twice per event.

**Fix:** Call `nube.off(event, listener)` before `nube.on(event, listener)` in `onEvent`. This is a no-op when the listener isn't registered yet, and removes a prior registration when it is — ensuring at most one active subscription per (event, listener) pair. A regression test covers the deduplication behaviour.