### PR TITLE
Add related products slots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10743,7 +10743,7 @@
     },
     "packages/helper": {
       "name": "@tiendanube/nube-sdk-helper",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10842,7 +10842,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.78.0",
+      "version": "0.80.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.79.0",
+	"version": "0.80.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -146,8 +146,8 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_section_products_new"} AFTER_SECTION_PRODUCTS_NEW - After the products new section on the home page.
  * @property {"before_section_products_featured"} BEFORE_SECTION_PRODUCTS_FEATURED - Before the products featured section on the home page.
  * @property {"after_section_products_featured"} AFTER_SECTION_PRODUCTS_FEATURED - After the products featured section on the home page.
- * @property {"before_section_related_products"} BEFORE_SECTION_RELATED_PRODUCTS - Before the related products section on the product detail page.
- * @property {"after_section_related_products"} AFTER_SECTION_RELATED_PRODUCTS - After the related products section on the product detail page.
+ * @property {"before_product_detail_related_products"} BEFORE_PRODUCT_DETAIL_RELATED_PRODUCTS - Before the related products section on the product detail page.
+ * @property {"after_product_detail_related_products"} AFTER_PRODUCT_DETAIL_RELATED_PRODUCTS - After the related products section on the product detail page.
  * @property {"before_line_item"} BEFORE_LINE_ITEM - Before each cart line item.
  * @property {"cart_line_item_top"} CART_LINE_ITEM_TOP - Top of the cart line item. Deprecated; use BEFORE_LINE_ITEM instead.
  * @property {"before_footer"} BEFORE_FOOTER - Before the footer.
@@ -220,8 +220,10 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_SECTION_PRODUCTS_NEW: "after_section_products_new",
 	BEFORE_SECTION_PRODUCTS_FEATURED: "before_section_products_featured",
 	AFTER_SECTION_PRODUCTS_FEATURED: "after_section_products_featured",
-	BEFORE_SECTION_RELATED_PRODUCTS: "before_section_related_products",
-	AFTER_SECTION_RELATED_PRODUCTS: "after_section_related_products",
+	BEFORE_PRODUCT_DETAIL_RELATED_PRODUCTS:
+		"before_product_detail_related_products",
+	AFTER_PRODUCT_DETAIL_RELATED_PRODUCTS:
+		"after_product_detail_related_products",
 	BEFORE_LINE_ITEM: "before_line_item",
 	/** @deprecated Use BEFORE_LINE_ITEM instead. */
 	CART_LINE_ITEM_TOP: "cart_line_item_top",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -146,6 +146,8 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_section_products_new"} AFTER_SECTION_PRODUCTS_NEW - After the products new section on the home page.
  * @property {"before_section_products_featured"} BEFORE_SECTION_PRODUCTS_FEATURED - Before the products featured section on the home page.
  * @property {"after_section_products_featured"} AFTER_SECTION_PRODUCTS_FEATURED - After the products featured section on the home page.
+ * @property {"before_section_related_products"} BEFORE_SECTION_RELATED_PRODUCTS - Before the related products section on the product detail page.
+ * @property {"after_section_related_products"} AFTER_SECTION_RELATED_PRODUCTS - After the related products section on the product detail page.
  * @property {"before_line_item"} BEFORE_LINE_ITEM - Before each cart line item.
  * @property {"cart_line_item_top"} CART_LINE_ITEM_TOP - Top of the cart line item. Deprecated; use BEFORE_LINE_ITEM instead.
  * @property {"before_footer"} BEFORE_FOOTER - Before the footer.
@@ -218,6 +220,8 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_SECTION_PRODUCTS_NEW: "after_section_products_new",
 	BEFORE_SECTION_PRODUCTS_FEATURED: "before_section_products_featured",
 	AFTER_SECTION_PRODUCTS_FEATURED: "after_section_products_featured",
+	BEFORE_SECTION_RELATED_PRODUCTS: "before_section_related_products",
+	AFTER_SECTION_RELATED_PRODUCTS: "after_section_related_products",
 	BEFORE_LINE_ITEM: "before_line_item",
 	/** @deprecated Use BEFORE_LINE_ITEM instead. */
 	CART_LINE_ITEM_TOP: "cart_line_item_top",


### PR DESCRIPTION
## What

Adds two new storefront UI slots around the related products section on the product detail page:

- `before_section_related_products`
- `after_section_related_products`

## Changes

- `packages/types/src/slots.ts`: add both slots to `STOREFRONT_UI_SLOT` (with JSDoc).
- `packages/types/package.json`: bump to `0.80.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added two new storefront injection slot options around the product detail related-products section.
  * Expanded the set of supported slot placements to include these new targets.

* **Chores**
  * Bumped the package version to **0.80.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->