### PR TITLE
feat(types): add after_home_hero_banner slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 For release announcements, see [Discussions > Announcements](https://github.com/TiendaNube/nube-sdk/discussions/categories/announcements).
 
 ## [Unreleased]
+
+### Added
+
+- `AFTER_HOME_HERO_BANNER` slot (`after_home_hero_banner`) for placing content after the main hero/banner section on the home page, with fallback to the top of homepage content when no hero/banner is present.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.80.0",
+	"version": "0.81.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -163,6 +163,7 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_register_form_fields"} AFTER_REGISTER_FORM_FIELDS - After the fields of the customer registration form on the storefront register page.
  * @property {"before_register_form_submit"} BEFORE_REGISTER_FORM_SUBMIT - Before the submit button of the customer registration form on the storefront register page.
  * @property {"after_register_form_submit"} AFTER_REGISTER_FORM_SUBMIT - After the submit button of the customer registration form on the storefront register page.
+ * @property {"after_home_hero_banner"} AFTER_HOME_HERO_BANNER - After the main hero/banner section on the home page. If no hero/banner is present, renders at the top of homepage content.
  * @property {...typeof COMMON_UI_SLOT} - Includes all common UI slots.
  */
 export const STOREFRONT_UI_SLOT = {
@@ -243,6 +244,7 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_REGISTER_FORM_FIELDS: "after_register_form_fields",
 	BEFORE_REGISTER_FORM_SUBMIT: "before_register_form_submit",
 	AFTER_REGISTER_FORM_SUBMIT: "after_register_form_submit",
+	AFTER_HOME_HERO_BANNER: "after_home_hero_banner",
 } as const;
 
 /**


### PR DESCRIPTION
Adds `AFTER_HOME_HERO_BANNER` (`after_home_hero_banner`) to `STOREFRONT_UI_SLOT` in `packages/types/src/slots.ts`.

This slot targets the position immediately after the main hero/banner section on the home page. When no hero/banner is present, it falls back to the top of homepage content, ensuring a consistent and predictable insertion point across all storefronts.

Bumps `@tiendanube/nube-sdk-types` to `0.81.0`.