### PR TITLE
feat(types): Allow custom UI slot names at the `nube.render`

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.83.0",
+	"version": "0.84.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.84.0",
+	"version": "0.85.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.82.0",
+	"version": "0.83.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -20,7 +20,7 @@ import type {
 	NubeSDKSendableEvent,
 } from "./events";
 
-import type { UISlot } from "./slots";
+import type { UISlotArg } from "./slots";
 import type { DeepPartial, Nullable } from "./utility";
 
 /**
@@ -226,11 +226,12 @@ export type NubeSDK = {
 	 * The component can be either a static component or a function that receives the current state
 	 * and returns a component to render.
 	 *
-	 * @param slot - The UI slot where the component will be rendered.
+	 * @param slot - The UI slot where the component will be rendered. Custom
+	 * slot names (starting with `custom_`) are validated at the call site.
 	 * @param component - The component to render, either a static component or a function that returns a component based on the current state.
 	 */
-	render(
-		slot: UISlot,
+	render<const TSlot extends string>(
+		slot: UISlotArg<TSlot>,
 		component:
 			| NubeComponent
 			| NubeComponent[]
@@ -240,9 +241,10 @@ export type NubeSDK = {
 	/**
 	 * Clears a component from a specific UI slot, removing it from the NubeSDKState.
 	 *
-	 * @param slot - The UI slot from which the component will be cleared.
+	 * @param slot - The UI slot from which the component will be cleared. Custom
+	 * slot names (starting with `custom_`) are validated at the call site.
 	 */
-	clearSlot(slot: UISlot): void;
+	clearSlot<const TSlot extends string>(slot: UISlotArg<TSlot>): void;
 
 	/**
 	 * Retrieves the app settings values for the current app.

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -286,7 +286,148 @@ export type CheckoutUISlot = ObjectValues<typeof CHECKOUT_UI_SLOT>;
 export type StorefrontUISlot = ObjectValues<typeof STOREFRONT_UI_SLOT>;
 
 /**
+ * The set of characters allowed in the body of a custom slot name
+ * (i.e. the part after the `custom_` prefix).
+ *
+ * Only lowercase letters, digits and underscores are considered valid,
+ * which also enforces the `lowercase` and `snake_case` conventions.
+ */
+type AllowedCustomUISlotChar =
+	| "a"
+	| "b"
+	| "c"
+	| "d"
+	| "e"
+	| "f"
+	| "g"
+	| "h"
+	| "i"
+	| "j"
+	| "k"
+	| "l"
+	| "m"
+	| "n"
+	| "o"
+	| "p"
+	| "q"
+	| "r"
+	| "s"
+	| "t"
+	| "u"
+	| "v"
+	| "w"
+	| "x"
+	| "y"
+	| "z"
+	| "0"
+	| "1"
+	| "2"
+	| "3"
+	| "4"
+	| "5"
+	| "6"
+	| "7"
+	| "8"
+	| "9"
+	| "_";
+
+/**
+ * Recursively checks whether every character of `S` is an
+ * {@link AllowedCustomUISlotChar}.
+ *
+ * Resolves to `true` only when `S` is non-empty and made up exclusively of
+ * lowercase letters, digits and underscores; otherwise resolves to `false`.
+ *
+ * The non-literal `string` type resolves to `true`, since a value that is not
+ * a string literal cannot be validated at the type level and must be accepted.
+ *
+ * @template S - The custom slot body to validate (without the `custom_` prefix).
+ */
+type IsValidCustomUISlotBody<S extends string> = string extends S
+	? true
+	: S extends `${infer Head}${infer Tail}`
+		? Head extends AllowedCustomUISlotChar
+			? Tail extends ""
+				? true
+				: IsValidCustomUISlotBody<Tail>
+			: false
+		: false;
+
+/**
+ * Represents a custom slot defined by the store theme developer.
+ *
+ * A custom slot lets a theme expose its own injection points, following these rules:
+ *
+ * 1. It must always start with the `custom_` prefix.
+ * 2. It must be written in `snake_case`.
+ * 3. It must be entirely lowercase.
+ * 4. Only letters, numbers and `_` are valid characters.
+ *
+ * When used without a type argument (for example, as part of the {@link UISlot}
+ * union) it behaves as the broad ``custom_${string}`` template, matching any
+ * custom slot. When a string literal is provided as `T`, the rules above are
+ * enforced at the type level: valid names resolve to the literal itself, while
+ * invalid ones resolve to `never`.
+ *
+ * @template T - The custom slot name to validate. Defaults to `string`, which
+ * yields the broad ``custom_${string}`` type.
+ *
+ * @example
+ * ```ts
+ * type A = CustomUISlot<"custom_promo_banner">; // "custom_promo_banner"
+ * type B = CustomUISlot<"custom_promoBanner">;  // never (not lowercase / snake_case)
+ * type C = CustomUISlot<"custom_promo-banner">; // never (invalid character "-")
+ * type D = CustomUISlot<"promo_banner">;        // never (missing "custom_" prefix)
+ * type E = CustomUISlot;                         // `custom_${string}`
+ * ```
+ */
+export type CustomUISlot<T extends string = string> = string extends T
+	? `custom_${string}`
+	: T extends `custom_${infer Body}`
+		? IsValidCustomUISlotBody<Body> extends true
+			? T
+			: never
+		: never;
+
+/**
  * Represents all possible UI slots where components can be dynamically injected.
  * This type combines checkout, storefront, and common UI slots.
  */
-export type UISlot = Prettify<CheckoutUISlot | StorefrontUISlot>;
+export type UISlot = Prettify<CheckoutUISlot | StorefrontUISlot | CustomUISlot>;
+
+/**
+ * Validates a UI slot name provided as a string literal `S`.
+ *
+ * Predefined checkout and storefront slots resolve to themselves. Custom slots
+ * (those starting with `custom_`) are validated against the {@link CustomUISlot}
+ * rules, resolving to `S` when valid or `never` when invalid. Any other string
+ * resolves to `never`.
+ *
+ * This is meant to be used to constrain slot arguments so that invalid custom
+ * slot names are rejected at the call site (see {@link NubeSDK.render}).
+ *
+ * @template S - The slot name to validate.
+ */
+export type ValidateUISlot<S extends string> = S extends
+	| CheckoutUISlot
+	| StorefrontUISlot
+	? S
+	: S extends CustomUISlot
+		? CustomUISlot<S>
+		: never;
+
+/**
+ * Type of a slot argument for APIs such as {@link NubeSDK.render} and
+ * {@link NubeSDK.clearSlot}.
+ *
+ * It keeps the predefined checkout and storefront slots as direct union
+ * members, so editors still offer autocomplete for the fixed slot names, while
+ * validating custom slot names (starting with `custom_`) through the generic
+ * `TSlot` parameter via {@link ValidateUISlot}.
+ *
+ * @template TSlot - The literal type inferred from the slot argument.
+ */
+export type UISlotArg<TSlot extends string> =
+	| CheckoutUISlot
+	| StorefrontUISlot
+	| (TSlot & ValidateUISlot<TSlot>);


### PR DESCRIPTION
Enforce the custom slot naming rules (custom_ prefix, snake_case, lowercase, only [a-z0-9_]) at the type level via CustomUISlot, and make render/clearSlot generic so invalid custom slot names are rejected when used. Predefined checkout/storefront slots remain direct union members, preserving editor autocomplete for the fixed slot names.

Bump @tiendanube/nube-sdk-types to 0.83.0.

<img width="1186" height="898" alt="Screenshot 2026-07-07 at 10 16 27" src="https://github.com/user-attachments/assets/d10a78d8-a8fa-474a-9b9a-39dd00cc0bea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added type-level validation for custom UI slot names, enforcing allowed characters after the `custom_` prefix.
  * Improved slot typing so predefined slots keep autocomplete, while custom slots are validated more strictly.
* **Bug Fixes**
  * Updated UI slot argument handling for rendering and clearing to align with the validated slot name rules.
* **Chores**
  * Bumped the package version to **0.85.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->