### PR TITLE
feat(types): add PAGE_SCROLL event type and bump to 0.83.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10743,7 +10743,7 @@
     },
     "packages/helper": {
       "name": "@tiendanube/nube-sdk-helper",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10842,7 +10842,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.80.0",
+      "version": "0.84.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.83.0",
+	"version": "0.84.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.82.0",
+	"version": "0.83.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -81,6 +81,7 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {"quickbuy:open"} QUICKBUY_OPEN - Fired when the quickbuy modal is opened.
  * @property {"quickbuy:close"} QUICKBUY_CLOSE - Fired when the quickbuy modal is closed.
  * @property {"product:variant_selected"} PRODUCT_VARIANT_SELECTED - Fired when a product variant is selected.
+ * @property {"page:scroll"} PAGE_SCROLL - Fired when the page scroll position changes.
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
@@ -108,6 +109,7 @@ export const EVENT = {
 	QUICKBUY_OPEN: "quickbuy:open",
 	QUICKBUY_CLOSE: "quickbuy:close",
 	PRODUCT_VARIANT_SELECTED: "product:variant_selected",
+	PAGE_SCROLL: "page:scroll",
 	...SENDABLE_EVENT,
 } as const;
 


### PR DESCRIPTION
## Summary

- Add new `PAGE_SCROLL` event type (`page:scroll`) to the `EVENT` map, fired when the page scroll position changes
- Bump `@tiendanube/nube-sdk-types` version from `0.82.0` to `0.83.0`

## Changes

- `packages/types/src/events.ts`: new `PAGE_SCROLL: "page:scroll"` entry plus JSDoc
- `packages/types/package.json`: version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new `page:scroll` event, expanding the set of events available for tracking and listening.
* **Chores**
  * Updated the `@tiendanube/nube-sdk-types` package version from **0.83.0** to **0.84.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->