### PR TITLE
feat(events): add page exit intent and visibility change events

### DIFF
--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -81,6 +81,8 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {"quickbuy:open"} QUICKBUY_OPEN - Fired when the quickbuy modal is opened.
  * @property {"quickbuy:close"} QUICKBUY_CLOSE - Fired when the quickbuy modal is closed.
  * @property {"product:variant_selected"} PRODUCT_VARIANT_SELECTED - Fired when a product variant is selected.
+ * @property {"page:exit_intent"} PAGE_EXIT_INTENT - Fired when the cursor leaves through the top edge of the viewport (desktop exit intent).
+ * @property {"page:visibility_change"} PAGE_VISIBILITY_CHANGE - Fired when the store becomes hidden/backgrounded or the user switches tabs (mobile/touch).
  * @property {...typeof SENDABLE_EVENT} - Includes all sendable events.
  */
 export const EVENT = {
@@ -108,6 +110,8 @@ export const EVENT = {
 	QUICKBUY_OPEN: "quickbuy:open",
 	QUICKBUY_CLOSE: "quickbuy:close",
 	PRODUCT_VARIANT_SELECTED: "product:variant_selected",
+	PAGE_EXIT_INTENT: "page:exit_intent",
+	PAGE_VISIBILITY_CHANGE: "page:visibility_change",
 	...SENDABLE_EVENT,
 } as const;
 


### PR DESCRIPTION
## Description

Adds two new page-level events to the `EVENT` map in the types package:

- **`page:exit_intent`** (`PAGE_EXIT_INTENT`) — fired when the cursor leaves through the top edge of the viewport (desktop exit intent).
- **`page:visibility_change`** (`PAGE_VISIBILITY_CHANGE`) — fired when the store becomes hidden/backgrounded or the user switches tabs (mobile/touch).

Both include JSDoc annotations documenting when they fire.

## Changes

- `packages/types/src/events.ts` — new event keys plus their doc comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new page-level events related to exit intent and visibility changes.
  * These events can now be listened to by SDK integrations for richer browser interaction tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->