### PR TITLE
Require App ID and App name in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,7 +11,7 @@ body:
   - type: input
     id: app-id
     attributes:
-      label: App ID
+      label: App ID, numbers only
       description: Your application ID.
       placeholder: "e.g. 12345"
     validations:
@@ -21,8 +21,10 @@ body:
     id: app-name
     attributes:
       label: App name
-      description: Your application name (optional).
+      description: Your application name.
       placeholder: "e.g. My Payments App"
+    validations:
+      required: true
 
   - type: dropdown
     id: severity

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -11,16 +11,20 @@ body:
   - type: input
     id: app-id
     attributes:
-      label: App ID
-      description: Your application ID, if you already have one.
+      label: App ID, numbers only
+      description: Your application ID.
       placeholder: "e.g. 12345"
+    validations:
+      required: true
 
   - type: input
     id: app-name
     attributes:
       label: App name
-      description: Your application name (optional).
+      description: Your application name.
       placeholder: "e.g. My Payments App"
+    validations:
+      required: true
 
   - type: dropdown
     id: request-type


### PR DESCRIPTION
## Summary

1. Require App ID and App name in bug reports.
2. Require App ID and App name in feature requests.
3. Clarify that the App ID field expects numbers only.
4. Keep App name as unrestricted text.

## Why

Issues have been submitted without the application identifier or application name. Making both fields required improves the context available for triage.

## Validation

1. Parsed both Issue Form files as valid YAML.
2. Confirmed App ID and App name are required in both forms.
3. Confirmed `numbers only` appears exclusively in the App ID labels.
4. Confirmed the final diff passes `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved bug report and feature request forms with clearer application ID and app name guidance.
  * Added examples and validation requiring key application details in feature requests.
  * Clarified that application IDs must contain numbers only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->