### PR TITLE
feat(nube-sdk): add Video component with Player and YouTube support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+	"editor.formatOnSave": true,
+	"editor.codeActionsOnSave": {
+		"source.organizeImports.biome": "explicit"
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[javascriptreact]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[json]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10758,7 +10758,7 @@
     },
     "packages/jsx": {
       "name": "@tiendanube/nube-sdk-jsx",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10842,7 +10842,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.84.0",
+      "version": "0.86.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"
@@ -10854,7 +10854,7 @@
     },
     "packages/ui": {
       "name": "@tiendanube/nube-sdk-ui",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-jsx",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Library for building JSX interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jsx/src/components.tsx
+++ b/packages/jsx/src/components.tsx
@@ -127,6 +127,12 @@ import type {
 	NubeComponentToastTitleProps,
 	NubeComponentUse,
 	NubeComponentUseProps,
+	NubeComponentVideoPlayer,
+	NubeComponentVideoPlayerProps,
+	NubeComponentVideoRoot,
+	NubeComponentVideoRootProps,
+	NubeComponentVideoYouTube,
+	NubeComponentVideoYouTubeProps,
 } from "@tiendanube/nube-sdk-types";
 import {
 	accordionContent,
@@ -193,6 +199,9 @@ import {
 	toastDescription,
 	toastRoot,
 	toastTitle,
+	videoPlayer,
+	videoRoot,
+	videoYouTube,
 } from "@tiendanube/nube-sdk-ui";
 
 /**
@@ -430,6 +439,68 @@ export function Progress(
 export function Iframe(props: NubeComponentIframeProps): NubeComponentIframe {
 	return iframe(props);
 }
+
+/**
+ * Creates a `Video.Root` component.
+ *
+ * `Video.Root` is the source-agnostic wrapper for a video. It owns
+ * layout, the shared playback modifiers (`autoplay`, `muted`, `loop`) and the
+ * source-agnostic playback event handlers. Wrap a `Video.Player` or a
+ * `Video.YouTube` plus any overlay children (rendered over the video when the
+ * fullscreen lightbox is open).
+ *
+ * @param props - The properties for configuring the video root component.
+ * @returns A `NubeComponentVideoRoot` object representing the video root component.
+ */
+function VideoRoot(props: NubeComponentVideoRootProps): NubeComponentVideoRoot {
+	return videoRoot(props);
+}
+
+/**
+ * Creates a `Video.Player` component.
+ *
+ * `Video.Player` is a self-hosted video source (MP4, HLS or DASH) rendered by
+ * the SDK's bundled player engine. It must be a child of `Video.Root`. Emits
+ * source-specific errors through its own `onError`.
+ *
+ * @param props - The properties for configuring the video player component.
+ * @returns A `NubeComponentVideoPlayer` object representing the video player component.
+ */
+function VideoPlayer(
+	props: NubeComponentVideoPlayerProps,
+): NubeComponentVideoPlayer {
+	return videoPlayer(props);
+}
+
+/**
+ * Creates a `Video.YouTube` component.
+ *
+ * `Video.YouTube` embeds a YouTube video via the official IFrame Player API.
+ * It must be a child of `Video.Root`. No lightbox is available (YouTube ToS
+ * prohibits overlaying or cropping the embed). Emits source-specific errors
+ * through its own `onError`.
+ *
+ * @param props - The properties for configuring the YouTube video component.
+ * @returns A `NubeComponentVideoYouTube` object representing the YouTube component.
+ */
+function VideoYouTube(
+	props: NubeComponentVideoYouTubeProps,
+): NubeComponentVideoYouTube {
+	return videoYouTube(props);
+}
+
+/**
+ * Compound `Video` component.
+ *
+ * - `Video.Root` — wrapper owning layout, playback modifiers and events.
+ * - `Video.Player` — the self-hosted source (MP4 / HLS / DASH).
+ * - `Video.YouTube` — a YouTube embed via the official IFrame Player API.
+ */
+export const Video = {
+	Root: VideoRoot,
+	Player: VideoPlayer,
+	YouTube: VideoYouTube,
+};
 
 /**
  * Creates a `Select` component.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.85.0",
+	"version": "0.86.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -721,6 +721,227 @@ export type NubeComponentIframe = Prettify<
 >;
 
 /* -------------------------------------------------------------------------- */
+/*                           Video Component                                  */
+/* -------------------------------------------------------------------------- */
+
+/** Payload emitted with the `play`, `pause` and `ended` video events. */
+export type NubeComponentVideoTimePayload = {
+	/** Playback position in seconds when the event fired. */
+	currentTime: number;
+};
+
+/** Payload emitted with the `progress` video event (fires roughly every 1s). */
+export type NubeComponentVideoProgressPayload = {
+	percent: number;
+	currentTime: number;
+	duration: number;
+};
+
+/** Payload emitted with the `buffer` video event. */
+export type NubeComponentVideoBufferPayload = {
+	buffering: boolean;
+};
+
+export type NubeComponentVideoPlayHandler = NubeComponentEventHandler<
+	"play",
+	NubeComponentVideoTimePayload
+>;
+export type NubeComponentVideoPauseHandler = NubeComponentEventHandler<
+	"pause",
+	NubeComponentVideoTimePayload
+>;
+export type NubeComponentVideoEndedHandler = NubeComponentEventHandler<
+	"ended",
+	NubeComponentVideoTimePayload
+>;
+export type NubeComponentVideoProgressHandler = NubeComponentEventHandler<
+	"progress",
+	NubeComponentVideoProgressPayload
+>;
+export type NubeComponentVideoBufferHandler = NubeComponentEventHandler<
+	"buffer",
+	NubeComponentVideoBufferPayload
+>;
+
+/* -------------------------------------------------------------------------- */
+/*                      Video source-specific errors                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Error codes reported by `Video.Player` (the self-hosted MP4 / HLS / DASH
+ * source). `invalid_source` / `engine_load_failed` are raised by the SDK before
+ * playback; the four `media_err_*` codes mirror the HTML media element's
+ * `MediaError.code` as readable strings; `playback_error` covers a media
+ * failure with no known code.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaError/code
+ */
+export type NubeComponentVideoPlayerErrorCode =
+	| "invalid_source"
+	| "engine_load_failed"
+	| "media_err_aborted"
+	| "media_err_network"
+	| "media_err_decode"
+	| "media_err_src_not_supported"
+	| "playback_error";
+
+/**
+ * Payload delivered to `Video.Player`'s `onError`. `source` identifies the
+ * provider — errors are source-specific, so there is no shared union across
+ * providers (see {@link NubeComponentVideoYouTubeErrorPayload}).
+ */
+export type NubeComponentVideoPlayerErrorPayload = {
+	source: "video-player";
+	code: NubeComponentVideoPlayerErrorCode;
+	message: string;
+};
+
+/**
+ * Error codes reported by `Video.YouTube`. `invalid_source` is raised by the
+ * SDK before playback; the rest map the YouTube IFrame API's numeric `onError`
+ * codes to readable strings.
+ *
+ * @see https://developers.google.com/youtube/iframe_api_reference#onError
+ */
+export type NubeComponentVideoYouTubeErrorCode =
+	| "invalid_source"
+	| "invalid_video_id"
+	| "html5_error"
+	| "video_not_found"
+	| "embedding_not_allowed"
+	| "playback_error";
+
+/**
+ * Payload delivered to `Video.YouTube`'s `onError`. Its own `source` / `code`,
+ * distinct from {@link NubeComponentVideoPlayerErrorPayload} — there is no
+ * shared union across providers.
+ */
+export type NubeComponentVideoYouTubeErrorPayload = {
+	source: "video-youtube";
+	code: NubeComponentVideoYouTubeErrorCode;
+	message: string;
+};
+
+export type NubeComponentVideoPlayerErrorHandler = NubeComponentEventHandler<
+	"error",
+	NubeComponentVideoPlayerErrorPayload
+>;
+export type NubeComponentVideoYouTubeErrorHandler = NubeComponentEventHandler<
+	"error",
+	NubeComponentVideoYouTubeErrorPayload
+>;
+
+/**
+ * Properties for `Video.Root` — the source-agnostic wrapper that owns layout,
+ * shared playback modifiers and the source-agnostic playback events. Wrap a
+ * `Video.Player` (self-hosted) or a `Video.YouTube` (embed) plus any overlay
+ * children, which render over the video when the fullscreen lightbox is open.
+ *
+ * Errors are NOT here: they are source-specific and belong to each player
+ * (see `Video.Player`'s and `Video.YouTube`'s own `onError`).
+ */
+export type NubeComponentVideoRootProps = Prettify<
+	NubeComponentBase & {
+		width?: Size;
+		height?: Size;
+		style?: NubeComponentStyle;
+		/** Autoplay on mount. Always muted when `true` (enforced by the component). */
+		autoplay?: boolean;
+		muted?: boolean;
+		loop?: boolean;
+		onPlay?: NubeComponentVideoPlayHandler;
+		onPause?: NubeComponentVideoPauseHandler;
+		onEnded?: NubeComponentVideoEndedHandler;
+		onProgress?: NubeComponentVideoProgressHandler;
+		onBuffer?: NubeComponentVideoBufferHandler;
+		children: NubeComponentChildren;
+	}
+>;
+
+/**
+ * Represents a `Video.Root` component, the wrapper for a self-hosted video.
+ */
+export type NubeComponentVideoRoot = Prettify<
+	NubeComponentBase &
+		NubeComponentVideoRootProps & {
+			type: "videoRoot";
+		}
+>;
+
+/**
+ * Properties for `Video.Player` — a self-hosted video source (MP4, HLS or DASH)
+ * rendered by the SDK's bundled player engine. Must be a child of `Video.Root`.
+ */
+export type NubeComponentVideoPlayerProps = Prettify<
+	NubeComponentBase & {
+		/** Video source URL (HTTPS only). MP4, HLS (`.m3u8`) or DASH (`.mpd`). */
+		src: SecurityURL;
+		/** Poster image shown before playback (HTTPS only). */
+		poster?: SecurityURL;
+		/** Show the player's default controls. Defaults to `true`. */
+		controls?: boolean;
+		/**
+		 * Enable the fullscreen "lightbox": an absoluteFill overlay that fills the
+		 * viewport (CSS, not native fullscreen) with a mandatory close button and
+		 * `Video.Root`'s overlay children rendered on top.
+		 */
+		lightbox?: boolean;
+		/**
+		 * Observe source-specific errors from this player. The handler receives a
+		 * {@link NubeComponentVideoPlayerErrorPayload}. Distinct from `Video.Root`'s
+		 * source-agnostic playback events.
+		 */
+		onError?: NubeComponentVideoPlayerErrorHandler;
+	}
+>;
+
+/**
+ * Represents a `Video.Player` component, a self-hosted video source.
+ */
+export type NubeComponentVideoPlayer = Prettify<
+	NubeComponentBase &
+		NubeComponentVideoPlayerProps & {
+			type: "videoPlayer";
+		}
+>;
+
+/**
+ * Props for the `Video.YouTube` component.
+ */
+export type NubeComponentVideoYouTubeProps = Prettify<
+	NubeComponentBase & {
+		/** YouTube video ID (e.g. `"YE7VzlLtp-4"`) or a youtube.com / youtu.be URL. */
+		src: string;
+		/** Show the YouTube player controls. Defaults to `false`. */
+		controls?: boolean;
+		/**
+		 * Allow fullscreen via YouTube's native fullscreen button. Defaults to
+		 * `true`. The button lives in YouTube's control bar, so it is only
+		 * reachable when `controls` is `true`. No custom fullscreen overlay is
+		 * provided (prohibited by YouTube's embedded-player terms).
+		 */
+		allowFullscreen?: boolean;
+		/**
+		 * Observe source-specific errors from this embed. The handler receives a
+		 * {@link NubeComponentVideoYouTubeErrorPayload}. Distinct from
+		 * `Video.Root`'s source-agnostic playback events.
+		 */
+		onError?: NubeComponentVideoYouTubeErrorHandler;
+	}
+>;
+
+/**
+ * Represents a `Video.YouTube` component, a YouTube embed backed by the
+ * official IFrame Player API. No lightbox (ToS prohibits overlaying YouTube).
+ */
+export type NubeComponentVideoYouTube = Prettify<
+	NubeComponentBase &
+		NubeComponentVideoYouTubeProps & {
+			type: "videoYouTube";
+		}
+>;
+
+/* -------------------------------------------------------------------------- */
 /*                           Txt Component                                    */
 /* -------------------------------------------------------------------------- */
 
@@ -2424,6 +2645,9 @@ export type NubeComponent =
 	| NubeComponentImage
 	| NubeComponentProgress
 	| NubeComponentIframe
+	| NubeComponentVideoRoot
+	| NubeComponentVideoPlayer
+	| NubeComponentVideoYouTube
 	| NubeComponentText
 	| NubeComponentCheckbox
 	| NubeComponentTextarea

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-ui",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Library for building declarative interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/src/components/video.ts
+++ b/packages/ui/src/components/video.ts
@@ -1,0 +1,67 @@
+import type {
+	NubeComponentVideoPlayer,
+	NubeComponentVideoPlayerProps,
+	NubeComponentVideoRoot,
+	NubeComponentVideoRootProps,
+	NubeComponentVideoYouTube,
+	NubeComponentVideoYouTubeProps,
+} from "@tiendanube/nube-sdk-types";
+import { generateInternalId } from "./generateInternalId";
+
+/**
+ * Creates a `videoRoot` component.
+ *
+ * `Video.Root` is the source-agnostic wrapper for a video. It owns
+ * layout (`width`, `height`, `style`), shared playback modifiers (`autoplay`,
+ * `muted`, `loop`) and the source-agnostic playback event handlers (`onPlay`,
+ * `onPause`, `onEnded`, `onProgress`, `onBuffer`). It must contain a
+ * `Video.Player` or a `Video.YouTube`, optionally followed by overlay children
+ * that render over the video when the fullscreen lightbox is open. Errors are
+ * source-specific and belong to each player's own `onError`.
+ *
+ * @param props - The properties for configuring the video root component.
+ * @returns A `NubeComponentVideoRoot` object representing the video root component.
+ */
+export const videoRoot = (
+	props: NubeComponentVideoRootProps,
+): NubeComponentVideoRoot => ({
+	type: "videoRoot",
+	...props,
+	__internalId: generateInternalId("videoRoot", props),
+});
+
+/**
+ * Creates a `videoPlayer` component.
+ *
+ * `Video.Player` is a self-hosted video source (MP4, HLS or DASH) rendered by
+ * the SDK's bundled player engine. It must be a child of `Video.Root`, which
+ * owns the shared playback modifiers and events.
+ *
+ * @param props - The properties for configuring the video player component.
+ * @returns A `NubeComponentVideoPlayer` object representing the video player component.
+ */
+export const videoPlayer = (
+	props: NubeComponentVideoPlayerProps,
+): NubeComponentVideoPlayer => ({
+	type: "videoPlayer",
+	...props,
+	__internalId: generateInternalId("videoPlayer", props),
+});
+
+/**
+ * Creates a `videoYouTube` component.
+ *
+ * `Video.YouTube` embeds a YouTube video via the official IFrame Player API.
+ * It must be a child of `Video.Root`. No lightbox is available (YouTube ToS
+ * prohibits overlaying or cropping the embed).
+ *
+ * @param props - The properties for configuring the YouTube video component.
+ * @returns A `NubeComponentVideoYouTube` object representing the YouTube component.
+ */
+export const videoYouTube = (
+	props: NubeComponentVideoYouTubeProps,
+): NubeComponentVideoYouTube => ({
+	type: "videoYouTube",
+	...props,
+	__internalId: generateInternalId("videoYouTube", props),
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,7 @@ export * from "./components/fragment";
 export * from "./components/image";
 export * from "./components/progress";
 export * from "./components/iframe";
+export * from "./components/video";
 export * from "./components/text";
 export * from "./components/checkbox";
 export * from "./components/textarea";


### PR DESCRIPTION
This PR adds new components for self-hosted and YouTube videos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video components for self-hosted playback and YouTube embeds.
  * Added support for playback controls, progress and buffering events, and provider-specific error handling.
  * Added a compound JSX API with `Video.Root`, `Video.Player`, and `Video.YouTube`.

* **Chores**
  * Updated package versions for the video component, type definitions, and JSX packages.
  * Added recommended VS Code formatting and import-organization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->