### PR TITLE
feat(nube-sdk): gate cart add/remove on opt-in apps via before-update handshake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7042,7 +7042,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7064,7 +7063,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7086,7 +7084,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7108,7 +7105,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7130,7 +7126,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7152,7 +7147,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7174,7 +7168,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7196,7 +7189,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7218,7 +7210,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7240,7 +7231,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7262,7 +7252,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10694,7 +10683,7 @@
     },
     "packages/jsx": {
       "name": "@tiendanube/nube-sdk-jsx",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10778,7 +10767,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.89.1",
+      "version": "0.91.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"
@@ -10790,7 +10779,7 @@
     },
     "packages/ui": {
       "name": "@tiendanube/nube-sdk-ui",
-      "version": "0.21.0",
+      "version": "0.22.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.89.1",
+	"version": "0.90.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.90.0",
+	"version": "0.91.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -628,6 +628,8 @@ export type AppConfig = {
 	has_cart_validation: boolean;
 	/** Determines whether the user can select a shipping option. */
 	disable_shipping_more_options: boolean;
+	/** Determines whether the cart is handled before update. */
+	handle_cart_before_update: boolean;
 };
 /**
  * Represents a shipping option available in checkout.

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -14,6 +14,7 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  * @constant
  *
  * @property {"cart:validate"} CART_VALIDATE - Triggered to validate the current cart state.
+ * @property {"cart:before_update:result"} CART_BEFORE_UPDATE_RESULT - Used to send the result of the cart before update handling.
  * @property {"cart:add"} CART_ADD - Used to add a cart item.
  * @property {"cart:remove"} CART_REMOVE - Used to remove a cart item.
  * @property {"config:set"} CONFIG_SET - Used to update the SDK configuration.
@@ -28,6 +29,7 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  */
 export const SENDABLE_EVENT = {
 	CART_VALIDATE: "cart:validate",
+	CART_BEFORE_UPDATE_RESULT: "cart:before_update:result",
 	CART_ADD: "cart:add",
 	CART_REMOVE: "cart:remove",
 	CONFIG_SET: "config:set",
@@ -60,6 +62,7 @@ export type NubeSDKSendableEvent = Prettify<
  * @property {"*"} ALL - Wildcard listener for all events.
  * @property {"page:loaded"} PAGE_LOADED - Fired when the page is loaded and the SDK is ready to be used.
  * @property {"cart:update"} CART_UPDATE - Fired when the cart state is updated.
+ * @property {"cart:before_update"} CART_BEFORE_UPDATE - Fired before the cart state is updated.
  * @property {"cart:view"} CART_VIEW - Fired when the user views their shopping cart.
  * @property {"cart:add:success"} CART_ADD_SUCCESS - Fired when a cart item is added successfully.
  * @property {"cart:add:fail"} CART_ADD_FAIL - Fired when a cart item is added unsuccessfully.
@@ -90,6 +93,7 @@ export const EVENT = {
 	ALL: "*",
 	PAGE_LOADED: "page:loaded",
 	CART_UPDATE: "cart:update",
+	CART_BEFORE_UPDATE: "cart:before_update",
 	CART_VIEW: "cart:view",
 	CART_ADD_SUCCESS: "cart:add:success",
 	CART_REMOVE_SUCCESS: "cart:remove:success",


### PR DESCRIPTION
## Summary

Introduces the type-level surface for gating `cart:add`/`cart:remove` behind a `cart:before_update` handshake for apps that opt in.

- Adds `handle_cart_before_update` flag to `AppConfig` — apps opt in to handling the cart before it's updated.
- Adds `CART_BEFORE_UPDATE` (`cart:before_update`) listenable event, fired before the cart state is updated.
- Adds `CART_BEFORE_UPDATE_RESULT` (`cart:before_update:result`) sendable event, used by the app to send back the result of its before-update handling.

## Changes

- `packages/types/src/domain.ts` — new `handle_cart_before_update: boolean` on `AppConfig`.
- `packages/types/src/events.ts` — new entries in `SENDABLE_EVENT` and `EVENT` with accompanying JSDoc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for handling cart updates before they are applied.
  - Added a configurable option to control pre-update cart handling.
  - Added events for listening to cart pre-update activity and sending the resulting response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->