### PR TITLE
feat(types): add available slots discovery adapter to api namespace

### DIFF
--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsCommands } from "./analytics";
+import type { AvailableSlotsCommands } from "./available-slots";
 import type { CheckoutCommands } from "./checkout";
 
 /**
@@ -23,4 +24,11 @@ export type NubeAPI = {
 	 * instance — identity comparisons (`===`) hold.
 	 */
 	getAnalytics(): AnalyticsCommands;
+
+	/**
+	 * Returns the available-slots adapter, used to discover the static and
+	 * dynamic slots present on the current page. Subsequent calls return the
+	 * same instance — identity comparisons (`===`) hold.
+	 */
+	getAvailableSlots(): AvailableSlotsCommands;
 };

--- a/packages/types/src/available-slots.ts
+++ b/packages/types/src/available-slots.ts
@@ -1,0 +1,89 @@
+import type { CheckoutUISlot, DynamicUISlot, StorefrontUISlot } from "./slots";
+import type { Prettify } from "./utility";
+
+/**
+ * A static slot present on the current page — the richer shape returned by
+ * {@link AvailableSlotsCommands.getStatic}.
+ *
+ * `pick` is what differentiates a repeatable slot (product-grid items, line
+ * items) from a non-repeatable one, so it is promoted into the type alongside
+ * the derived {@link StaticSlot.isRepeatable} flag.
+ */
+export type StaticSlot = {
+	/**
+	 * The slot name (a known checkout/storefront slot, not an arbitrary
+	 * string). This is also the key under which `render` writes the slot into
+	 * `NubeSDKState["ui"]["slots"]`.
+	 */
+	slotId: Prettify<CheckoutUISlot | StorefrontUISlot>;
+	/**
+	 * Disambiguation key for repeatable static slots (e.g. `product.id` for
+	 * product-grid items, or the line-item id). `null` for non-repeatable
+	 * slots.
+	 */
+	pick: string | null;
+	/**
+	 * Whether the slot is repeatable. Auto-calculated: a slot is repeatable iff
+	 * it carries a `pick` (`isRepeatable === (pick !== null)`), so consumers
+	 * read it directly instead of re-deriving it.
+	 */
+	isRepeatable: boolean;
+};
+
+/**
+ * The two dynamic-section slot prefixes (without the trailing `_`), used as the
+ * {@link DynamicSlot.type} discriminant.
+ */
+export type DynamicSlotType =
+	| "before_dynamic_section"
+	| "after_dynamic_section";
+
+/**
+ * A dynamic slot present on the current page — the richer shape returned by
+ * {@link AvailableSlotsCommands.getDynamic}.
+ *
+ * A dynamic slot is injected around a theme section that the store owner can
+ * add, remove or reorder, so the same logical slot can exist many times on a
+ * page (one instance per section). It carries the section's coordinates so an
+ * app can find the instance it wants (e.g.
+ * `dynamics.find(s => s.sectionType === "product-list")`); `slotId` is the
+ * addressable name it then passes to `render` / `clearSlot`.
+ */
+export type DynamicSlot = {
+	/** Whether the slot sits before or after its dynamic section. */
+	type: DynamicSlotType;
+	/** The section's type (e.g. `"product-list"`). */
+	sectionType: string;
+	/** The section instance id generated when the page is built. */
+	sectionId: string;
+	/** The section's position among the page's dynamic sections. */
+	sectionIndex: number;
+	/**
+	 * The dynamic slot's name — a {@link DynamicUISlot} built from the section
+	 * coordinates. This is the key under which `render` writes the slot into
+	 * `NubeSDKState["ui"]["slots"]`.
+	 */
+	slotId: DynamicUISlot;
+};
+
+/**
+ * Adapter exposed on `NubeSDK` as `nube.api.getAvailableSlots()`. Lets an app
+ * discover the slots present on the current page — both static and dynamic —
+ * so it can render into them (see {@link DynamicSlot} for why dynamic slots
+ * need discovery).
+ *
+ * The methods are `async` because the data lives on the main thread (the DOM)
+ * and is fetched across the worker / main thread boundary via the internal
+ * command channel.
+ */
+export type AvailableSlotsCommands = {
+	/** Returns only the static slots present on the current page. */
+	getStatic(): Promise<StaticSlot[]>;
+	/**
+	 * Returns only the dynamic slots present on the current page, each carrying
+	 * its section coordinates.
+	 */
+	getDynamic(): Promise<DynamicSlot[]>;
+	/** Returns both buckets at once — the whole available-slots registry. */
+	getAll(): Promise<{ static: StaticSlot[]; dynamic: DynamicSlot[] }>;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,7 @@
 // Type exports
+export type * from "./analytics";
 export type * from "./api";
+export type * from "./available-slots";
 export type * from "./browser";
 export type * from "./app-settings";
 export type * from "./checkout";

--- a/packages/types/src/main.ts
+++ b/packages/types/src/main.ts
@@ -1,5 +1,6 @@
 import type { NubeAPI } from "./api";
 import type { AppSettingsValues } from "./app-settings";
+import type { DynamicSlot, StaticSlot } from "./available-slots";
 import type { NubeBrowserAPIs } from "./browser";
 import type { NubeComponent, UI } from "./components";
 import type {
@@ -226,12 +227,14 @@ export type NubeSDK = {
 	 * The component can be either a static component or a function that receives the current state
 	 * and returns a component to render.
 	 *
-	 * @param slot - The UI slot where the component will be rendered. Custom
-	 * slot names (starting with `custom_`) are validated at the call site.
+	 * @param slot - The UI slot where the component will be rendered. Accepts a
+	 * slot name (custom slot names starting with `custom_`, and dynamic slot
+	 * names, are validated at the call site) or a `StaticSlot` / `DynamicSlot`
+	 * object returned by `nube.api.getAvailableSlots()`.
 	 * @param component - The component to render, either a static component or a function that returns a component based on the current state.
 	 */
 	render<const TSlot extends string>(
-		slot: UISlotArg<TSlot>,
+		slot: UISlotArg<TSlot> | StaticSlot | DynamicSlot,
 		component:
 			| NubeComponent
 			| NubeComponent[]
@@ -241,10 +244,14 @@ export type NubeSDK = {
 	/**
 	 * Clears a component from a specific UI slot, removing it from the NubeSDKState.
 	 *
-	 * @param slot - The UI slot from which the component will be cleared. Custom
-	 * slot names (starting with `custom_`) are validated at the call site.
+	 * @param slot - The UI slot from which the component will be cleared. Accepts
+	 * a slot name (custom slot names starting with `custom_`, and dynamic slot
+	 * names, are validated at the call site) or a `StaticSlot` / `DynamicSlot`
+	 * object returned by `nube.api.getAvailableSlots()`.
 	 */
-	clearSlot<const TSlot extends string>(slot: UISlotArg<TSlot>): void;
+	clearSlot<const TSlot extends string>(
+		slot: UISlotArg<TSlot> | StaticSlot | DynamicSlot,
+	): void;
 
 	/**
 	 * Retrieves the app settings values for the current app.


### PR DESCRIPTION
Add the AvailableSlots discovery API so apps can enumerate the static and dynamic slots present on the current page:
- add `AvailableSlotsCommands` (`getStatic`/`getDynamic`/`getAll`) plus the `StaticSlot` / `DynamicSlot` discovery shapes (`DynamicSlot.slotId` reuses `DynamicUISlot`)
- wire `getAvailableSlots()` into the `NubeAPI` namespace, alongside `getCheckout()` / `getAnalytics()`
- widen `render` / `clearSlot` to also accept a `StaticSlot` / `DynamicSlot` object returned by discovery, in addition to a slot name
- export `available-slots` and the (previously unexported) `analytics` module from the package index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added APIs for discovering available static and dynamic UI slots.
  * Added support for retrieving all available slots or filtering by slot type.
  * UI slots can now be rendered or cleared using slot descriptors in addition to slot names.
  * Expanded public type exports for analytics and available-slot functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->