### PR TITLE
feat(types): add placeholder and disabled properties to field and select components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10842,7 +10842,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.88.0",
+      "version": "0.89.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10842,7 +10842,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.84.0",
+      "version": "0.88.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.88.0",
+	"version": "0.89.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.87.0",
+	"version": "0.88.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -230,6 +230,8 @@ export type NubeComponentFieldProps = Prettify<
 		name: string;
 		label: string;
 		value?: string;
+		placeholder?: string;
+		disabled?: boolean;
 		mask?: string;
 		autoFocus?: boolean;
 		style?: {
@@ -414,11 +416,12 @@ export type NubeComponentSelectProps = Prettify<
 		name: string;
 		label: string;
 		value?: string;
+		disabled?: boolean;
 		style?: {
 			label?: NubeComponentStyle;
 			select?: NubeComponentStyle;
 		};
-		options: { label: string; value: string }[];
+		options: { label: string; value: string; disabled?: boolean }[];
 		onChange?: NubeComponentSelectEventHandler;
 	}
 >;


### PR DESCRIPTION
## Summary

Adds new optional properties to component prop types in `packages/types`:

- **`NubeComponentFieldProps`**: adds `placeholder?: string` and `disabled?: boolean`
- **`NubeComponentSelectProps`**: adds `disabled?: boolean`, and `disabled?: boolean` to each entry in `options`

## Changes

- `packages/types/src/components.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Form fields now support placeholder text and disabled states.
  - Select controls can be disabled entirely or restrict individual options (including per-option disabled).

- **Chores**
  - Updated the SDK types package version to include the revised public prop typings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->