### PR TITLE
feat(devtools): add resizable columns and clipboard copy to event table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10771,7 +10771,7 @@
       }
     },
     "packages/nube-devtools": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@microlink/react-json-view": "^1.31.20",

--- a/packages/nube-devtools/package.json
+++ b/packages/nube-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nube-devtools",
   "displayName": "nube-devtools",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Tiendanube / Nuvemshop",
   "description": "Chrome DevTools extension for debugging and testing NubeSDK apps with real-time insights.",
   "type": "module",

--- a/packages/nube-devtools/src/devtools/components/event-table-row.tsx
+++ b/packages/nube-devtools/src/devtools/components/event-table-row.tsx
@@ -6,8 +6,9 @@ import {
 } from "@/components/ui/context-menu";
 import { TableCell, TableRow } from "@/components/ui/table";
 import type { NubeSDKEvent } from "@/contexts/nube-sdk-events-context";
-import { Repeat } from "lucide-react";
+import { Copy, ListFilterPlus, Repeat } from "lucide-react";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 export type EventCellField = "sender" | "target" | "event";
 
@@ -19,22 +20,43 @@ type EventTableRowProps = {
 	onAddToFilter: (field: EventCellField, value: string) => void;
 };
 
-function FilterMenuItem({
+function EventContextMenuContent({
 	field,
 	value,
+	event,
 	onAddToFilter,
+	onResend,
 }: {
 	field: EventCellField;
 	value: string;
+	event: NubeSDKEvent;
 	onAddToFilter: (field: EventCellField, value: string) => void;
+	onResend: (event: NubeSDKEvent) => void;
 }) {
 	return (
-		<ContextMenuItem onSelect={() => onAddToFilter(field, value)}>
-			Add to filter:
-			<span className="text-muted-foreground ml-1">
-				{field}=&quot;{value}&quot;
-			</span>
-		</ContextMenuItem>
+		<ContextMenuContent>
+			<ContextMenuItem onSelect={() => onAddToFilter(field, value)}>
+				<ListFilterPlus className="h-3 w-3 mr-2" />
+				Add to filter:
+				<span className="text-muted-foreground ml-1">
+					{field}=&quot;{value}&quot;
+				</span>
+			</ContextMenuItem>
+			<ContextMenuItem
+				onSelect={() => {
+					navigator.clipboard.writeText(value).then(() => {
+						toast.success("Copied to clipboard");
+					});
+				}}
+			>
+				<Copy className="h-3 w-3 mr-2" />
+				Copy {field}
+			</ContextMenuItem>
+			<ContextMenuItem onSelect={() => onResend(event)}>
+				<Repeat className="h-3 w-3 mr-2" />
+				Resend event
+			</ContextMenuItem>
+		</ContextMenuContent>
 	);
 }
 
@@ -70,13 +92,13 @@ export function EventTableRow({
 						{sender}
 					</TableCell>
 				</ContextMenuTrigger>
-				<ContextMenuContent>
-					<FilterMenuItem
-						field="sender"
-						value={sender}
-						onAddToFilter={onAddToFilter}
-					/>
-				</ContextMenuContent>
+				<EventContextMenuContent
+					field="sender"
+					value={sender}
+					event={event}
+					onAddToFilter={onAddToFilter}
+					onResend={onResend}
+				/>
 			</ContextMenu>
 
 			<ContextMenu>
@@ -85,42 +107,30 @@ export function EventTableRow({
 						{target}
 					</TableCell>
 				</ContextMenuTrigger>
-				<ContextMenuContent>
-					<FilterMenuItem
-						field="target"
-						value={target}
-						onAddToFilter={onAddToFilter}
-					/>
-				</ContextMenuContent>
+				<EventContextMenuContent
+					field="target"
+					value={target}
+					event={event}
+					onAddToFilter={onAddToFilter}
+					onResend={onResend}
+				/>
 			</ContextMenu>
 
 			<TableCell className="px-3 py-2">
-				<div className="flex items-center w-full min-w-0 gap-1">
-					<ContextMenu>
-						<ContextMenuTrigger asChild>
-							<span className="truncate block flex-1 min-w-0" title={eventName}>
-								{eventName}
-							</span>
-						</ContextMenuTrigger>
-						<ContextMenuContent>
-							<FilterMenuItem
-								field="event"
-								value={eventName}
-								onAddToFilter={onAddToFilter}
-							/>
-						</ContextMenuContent>
-					</ContextMenu>
-					<button
-						type="button"
-						onClick={(e) => {
-							e.stopPropagation();
-							onResend(event);
-						}}
-						className="h-6 w-6 p-0 shrink-0 inline-flex items-center justify-center rounded-md border border-input bg-background text-sm hover:bg-accent hover:text-accent-foreground"
-					>
-						<Repeat className="h-3 w-3 transition-all duration-300 ease-in-out" />
-					</button>
-				</div>
+				<ContextMenu>
+					<ContextMenuTrigger asChild>
+						<span className="truncate block w-full min-w-0" title={eventName}>
+							{eventName}
+						</span>
+					</ContextMenuTrigger>
+					<EventContextMenuContent
+						field="event"
+						value={eventName}
+						event={event}
+						onAddToFilter={onAddToFilter}
+						onResend={onResend}
+					/>
+				</ContextMenu>
 			</TableCell>
 		</TableRow>
 	);

--- a/packages/nube-devtools/src/devtools/pages/events.tsx
+++ b/packages/nube-devtools/src/devtools/pages/events.tsx
@@ -3,7 +3,13 @@ import { Divider } from "@/components/ui/divider";
 import { ResizableHandle, ResizablePanel } from "@/components/ui/resizable";
 import { ResizablePanelGroup } from "@/components/ui/resizable";
 import { SidebarTrigger } from "@/components/ui/sidebar";
-import { Table, TableBody } from "@/components/ui/table";
+import {
+	Table,
+	TableBody,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useNubeSDKEventsContext } from "@/contexts/nube-sdk-events-context";
 import type {
 	NubeSDKEvent,
@@ -22,6 +28,28 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 const STORAGE_KEY = "nube-devtools-events-page-width";
 const SEARCH_STORAGE_KEY = "nube-devtools-filter-search";
+const COLUMN_WIDTHS_KEY = "nube-devtools-events-column-widths";
+
+type ResizableColumn = "sender" | "target";
+type ColumnWidths = Record<ResizableColumn, number>;
+const DEFAULT_COLUMN_WIDTHS: ColumnWidths = { sender: 150, target: 150 };
+const MIN_COLUMN_WIDTH = 60;
+
+function loadColumnWidths(): ColumnWidths {
+	const stored = localStorage.getItem(COLUMN_WIDTHS_KEY);
+	if (stored) {
+		try {
+			const parsed = JSON.parse(stored) as Partial<ColumnWidths>;
+			return {
+				sender: parsed.sender ?? DEFAULT_COLUMN_WIDTHS.sender,
+				target: parsed.target ?? DEFAULT_COLUMN_WIDTHS.target,
+			};
+		} catch {
+			// ignore malformed value and fall back to defaults
+		}
+	}
+	return DEFAULT_COLUMN_WIDTHS;
+}
 
 type QueryField = "sender" | "target" | "event";
 const QUERY_FIELDS: ReadonlySet<string> = new Set([
@@ -80,6 +108,40 @@ export function Events() {
 		return localStorage.getItem(SEARCH_STORAGE_KEY) || "";
 	});
 	const tableContainerRef = useRef<HTMLDivElement>(null);
+	const [columnWidths, setColumnWidths] =
+		useState<ColumnWidths>(loadColumnWidths);
+
+	useEffect(() => {
+		localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths));
+	}, [columnWidths]);
+
+	const startColumnResize = (
+		column: ResizableColumn,
+		event: React.MouseEvent,
+	) => {
+		event.preventDefault();
+		event.stopPropagation();
+		const startX = event.clientX;
+		const startWidth = columnWidths[column];
+
+		const handleMouseMove = (moveEvent: MouseEvent) => {
+			const delta = moveEvent.clientX - startX;
+			const nextWidth = Math.max(MIN_COLUMN_WIDTH, startWidth + delta);
+			setColumnWidths((prev) => ({ ...prev, [column]: nextWidth }));
+		};
+
+		const handleMouseUp = () => {
+			window.removeEventListener("mousemove", handleMouseMove);
+			window.removeEventListener("mouseup", handleMouseUp);
+			document.body.style.cursor = "";
+			document.body.style.userSelect = "";
+		};
+
+		window.addEventListener("mousemove", handleMouseMove);
+		window.addEventListener("mouseup", handleMouseUp);
+		document.body.style.cursor = "col-resize";
+		document.body.style.userSelect = "none";
+	};
 
 	useEffect(() => {
 		const query = parseQuery(search);
@@ -246,36 +308,50 @@ export function Events() {
 									/>
 								</div>
 							) : (
-								<div className="flex h-full flex-col">
-									<div className="flex items-center border-b text-xs text-muted-foreground shrink-0 h-7">
-										<div className="w-[30%] px-3 truncate border-r">sender</div>
-										<div className="w-[30%] px-3 truncate border-r">target</div>
-										<div className="flex-1 px-3 truncate">event</div>
-									</div>
-									<div
-										ref={tableContainerRef}
-										className="flex-1 overflow-y-auto"
-									>
-										<Table className="table-fixed">
-											<colgroup>
-												<col className="w-[30%]" />
-												<col className="w-[30%]" />
-												<col />
-											</colgroup>
-											<TableBody>
-												{filteredEvents.map((event) => (
-													<EventTableRow
-														key={event.id}
-														event={event}
-														isSelected={event.id === selectedEvent?.id}
-														onSelect={setSelectedEvent}
-														onResend={(e) => handleReplayEvent(e.data)}
-														onAddToFilter={handleAddToFilter}
+								<div ref={tableContainerRef} className="h-full overflow-y-auto">
+									<Table className="table-fixed">
+										<TableHeader>
+											<TableRow>
+												<TableHead
+													style={{ width: columnWidths.sender }}
+													className="relative h-7 px-3 text-muted-foreground border-r"
+												>
+													sender
+													<button
+														type="button"
+														onMouseDown={(e) => startColumnResize("sender", e)}
+														className="absolute top-0 right-0 h-full w-1.5 translate-x-1/2 cursor-ew-resize border-0 bg-transparent p-0"
 													/>
-												))}
-											</TableBody>
-										</Table>
-									</div>
+												</TableHead>
+												<TableHead
+													style={{ width: columnWidths.target }}
+													className="relative h-7 px-3 text-muted-foreground border-r"
+												>
+													target
+													<button
+														type="button"
+														onMouseDown={(e) => startColumnResize("target", e)}
+														className="absolute top-0 right-0 h-full w-1.5 translate-x-1/2 cursor-ew-resize border-0 bg-transparent p-0"
+													/>
+												</TableHead>
+												<TableHead className="h-7 px-3 text-muted-foreground">
+													event
+												</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody className="[&_tr:last-child]:border-b!">
+											{filteredEvents.map((event) => (
+												<EventTableRow
+													key={event.id}
+													event={event}
+													isSelected={event.id === selectedEvent?.id}
+													onSelect={setSelectedEvent}
+													onResend={(e) => handleReplayEvent(e.data)}
+													onAddToFilter={handleAddToFilter}
+												/>
+											))}
+										</TableBody>
+									</Table>
 								</div>
 							)}
 						</ResizablePanel>


### PR DESCRIPTION
## Summary

Enhances the DevTools events table with resizable columns and clipboard copy functionality.

- **Resizable columns**: `sender` and `target` columns can now be resized by dragging their right edge. Widths are persisted to `localStorage` and restored on load (with a `60px` minimum width).
- **Table refactor**: replaces the custom flex-based header/body layout with proper `TableHeader`/`TableRow`/`TableHead` components for a consistent table structure.
- **Clipboard copy**: adds copy-to-clipboard support in the event table rows.

## Screenshots

<img width="1172" height="692" alt="Captura de Tela 2026-07-21 às 20 58 12" src="https://github.com/user-attachments/assets/de9ca406-9695-47a7-b6d2-cad46f10476b" />

## Test plan

- [x] Resize `sender`/`target` columns by dragging; verify minimum width is respected
- [x] Reload the page and confirm column widths persist
- [x] Copy event data to clipboard and verify contents
- [x] Verify filtering and event selection still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-menu actions for event cells: add the current value to a filter, copy the value to the clipboard, and resend the event.
  * Added resizable “Sender” and “Target” table columns on the Events page.
  * Persisted column widths automatically between sessions.

* **Improvements**
  * Consolidated event-related actions into the context menu and removed the standalone resend control.

* **Chores**
  * Bumped the devtools package version to 1.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->