### PR TITLE
feat(types): add value property to NubeComponentFormFieldProps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10842,7 +10842,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.89.0",
+      "version": "0.89.1",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.89.0",
+	"version": "0.89.1",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -1216,6 +1216,8 @@ export type NubeComponentFormFieldProps = Prettify<
 			accept?: string;
 			/** Maximum file size in bytes, only for `inputType: "file"`. */
 			maxSize?: number;
+			/** Current value of the field. */
+			value?: string;
 			/** Style slots, same shape as `Field.style` for visual parity. */
 			style?: {
 				container?: NubeComponentStyle;

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -1207,8 +1207,11 @@ export type NubeComponentFormFieldProps = Prettify<
 			name: string;
 			/** Floating label rendered next to the input (mirrors `Field.label`). */
 			label: string;
+			/** Marks the field as required, failing with `valueMissing` when empty. */
 			required?: boolean;
+			/** Minimum number of characters, failing with `tooShort` when unmet. */
 			minLength?: number;
+			/** Maximum number of characters, failing with `tooLong` when exceeded. */
 			maxLength?: number;
 			/** Regular expression source used for `pattern` validation. */
 			pattern?: string;


### PR DESCRIPTION
## Summary
- Adds an optional `value` property to `NubeComponentFormFieldProps` to expose the current value of a form field.

## Changes
- [packages/types/src/components.ts](packages/types/src/components.ts): new `value?: string` prop on `NubeComponentFormFieldProps`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form fields can now accept and display an optional current value.
* **Documentation**
  * Added inline descriptions for common validation-related form field options (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->