### PR TITLE
ci(devtools): publish Chrome extension to Chrome Web Store on release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,60 @@ jobs:
             export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             npx npm@11 publish --workspace packages/helper --access public
 
+  # --- CHROME WEB STORE (extensión NubeSDK DevTools) ---
+
+  publish-devtools:
+    executor: default
+    steps:
+      - checkout
+      - run:
+          name: Install Dependencies
+          command: npm ci
+      - run:
+          name: Build & zip NubeSDK DevTools extension
+          command: npm run zip -w packages/nube-devtools
+      - run:
+          name: Resolve zip path
+          command: |
+            VERSION=$(node -p "require('./packages/nube-devtools/package.json').version")
+            echo "export EXT_VERSION=${VERSION}" >> "$BASH_ENV"
+            echo "export ZIP_PATH=packages/nube-devtools/package/NubeSDK-DevTools-${VERSION}.zip" >> "$BASH_ENV"
+            source "$BASH_ENV"
+            ls -la "$ZIP_PATH"
+      - run:
+          name: Upload draft to Chrome Web Store (sin publicar)
+          command: |
+            # Intercambiamos el refresh token por un access token de corta duración
+            curl -sS -f -X POST https://oauth2.googleapis.com/token \
+              -d "client_id=${CHROME_CLIENT_ID}" \
+              -d "client_secret=${CHROME_CLIENT_SECRET}" \
+              -d "refresh_token=${CHROME_REFRESH_TOKEN}" \
+              -d "grant_type=refresh_token" -o token.json
+            ACCESS_TOKEN=$(node -p "require('./token.json').access_token")
+            # Subimos el zip como borrador (no se llama al endpoint /publish)
+            curl -sS -f \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              -H "x-goog-api-version: 2" \
+              -X PUT \
+              -T "${ZIP_PATH}" \
+              "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}"
+      - run:
+          name: Create GitHub release with zip asset
+          command: |
+            curl -sS -f -X POST \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases" \
+              -d "{\"tag_name\":\"${CIRCLE_TAG}\",\"name\":\"${CIRCLE_TAG}\",\"body\":\"NubeSDK DevTools ${EXT_VERSION}\"}" \
+              -o release.json
+            UPLOAD_URL=$(node -p "require('./release.json').upload_url.replace(/{.*}$/, '')")
+            ZIP_NAME=$(basename "${ZIP_PATH}")
+            curl -sS -f -X POST \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Content-Type: application/zip" \
+              --data-binary @"${ZIP_PATH}" \
+              "${UPLOAD_URL}?name=${ZIP_NAME}"
+
   # --- JOBS UNSTABLE (OIDC) ---
 
   publish-types-unstable:
@@ -347,6 +401,17 @@ workflows:
       - publish-helper:
           context: [npm_trusted]
           requires: [approval-publish-helper]
+
+      # --- CHROME WEB STORE (DevTools) ---
+      # Se dispara al crear una tag nube-sdk-* (no por branch).
+      # Sube el zip como borrador y crea la release en GitHub con el zip adjunto.
+      - publish-devtools:
+          context: [chrome_webstore]
+          filters:
+            tags:
+              only: /^nube-sdk-.*/
+            branches:
+              ignore: /.*/
 
       # --- UNSTABLE ---
       - approval-publish-types-unstable:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
 
   # --- CHROME WEB STORE (extensión NubeSDK DevTools) ---
 
-  publish-devtools:
+  upload-devtools-draft:
     executor: default
     steps:
       - checkout
@@ -213,6 +213,27 @@ jobs:
               -H "Content-Type: application/zip" \
               --data-binary @"${ZIP_PATH}" \
               "${UPLOAD_URL}?name=${ZIP_NAME}"
+
+  publish-devtools-store:
+    executor: default
+    steps:
+      - run:
+          name: Publish NubeSDK DevTools draft to Chrome Web Store
+          command: |
+            # Promueve a público el borrador ya subido por publish-devtools.
+            # No vuelve a subir el zip: solo llama al endpoint /publish del item.
+            curl -sS -f -X POST https://oauth2.googleapis.com/token \
+              -d "client_id=${CHROME_CLIENT_ID}" \
+              -d "client_secret=${CHROME_CLIENT_SECRET}" \
+              -d "refresh_token=${CHROME_REFRESH_TOKEN}" \
+              -d "grant_type=refresh_token" -o token.json
+            ACCESS_TOKEN=$(node -p "require('./token.json').access_token")
+            curl -sS -f \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              -H "x-goog-api-version: 2" \
+              -H "Content-Length: 0" \
+              -X POST \
+              "https://www.googleapis.com/chromewebstore/v1.1/items/${CHROME_EXTENSION_ID}/publish"
 
   # --- JOBS UNSTABLE (OIDC) ---
 
@@ -404,9 +425,26 @@ workflows:
 
       # --- CHROME WEB STORE (DevTools) ---
       # Se dispara al crear una tag nube-sdk-* (no por branch).
-      # Sube el zip como borrador y crea la release en GitHub con el zip adjunto.
-      - publish-devtools:
-          context: [chrome_webstore]
+      # 1) upload-devtools-draft: sube el zip como borrador y crea la release en GitHub.
+      # 2) approval: botón manual para promover el borrador a público.
+      # 3) publish-devtools-store: llama al endpoint /publish (solo tras aprobación).
+      # Secrets vienen de las Project Env Vars (CHROME_*, GITHUB_TOKEN), sin context.
+      - upload-devtools-draft:
+          filters:
+            tags:
+              only: /^nube-sdk-.*/
+            branches:
+              ignore: /.*/
+      - approval-publish-devtools:
+          type: approval
+          requires: [upload-devtools-draft]
+          filters:
+            tags:
+              only: /^nube-sdk-.*/
+            branches:
+              ignore: /.*/
+      - publish-devtools-store:
+          requires: [approval-publish-devtools]
           filters:
             tags:
               only: /^nube-sdk-.*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Chrome Web Store publish artifacts (contain OAuth tokens / API responses)
+token.json
+release.json
+
 # Logs
 logs
 *.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -681,9 +681,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -699,9 +696,6 @@
       "integrity": "sha512-9yjUfOFN7wrYsXt/T/gEWfvVxKlnh3yBpnScw98IF+oOeCYb5/b/+K7YNqKROV2i1DlMjg9g/EcN9wvj+NkMuQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
@@ -719,9 +713,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -737,9 +728,6 @@
       "integrity": "sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
@@ -3072,9 +3060,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3089,9 +3074,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3106,9 +3088,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3123,9 +3102,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3140,9 +3116,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3157,9 +3130,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3174,9 +3144,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3191,9 +3158,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3208,9 +3172,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3225,9 +3186,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3242,9 +3200,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3259,9 +3214,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3276,9 +3228,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3616,9 +3565,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3636,9 +3582,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3656,9 +3599,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3676,9 +3616,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7105,6 +7042,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7126,6 +7064,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7147,6 +7086,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7168,6 +7108,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7189,6 +7130,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7205,14 +7147,12 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7229,14 +7169,12 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7253,14 +7191,12 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7277,14 +7213,12 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7306,6 +7240,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7327,6 +7262,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10771,7 +10707,7 @@
       }
     },
     "packages/nube-devtools": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@microlink/react-json-view": "^1.31.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10707,7 +10707,7 @@
       }
     },
     "packages/nube-devtools": {
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
         "@microlink/react-json-view": "^1.31.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10707,7 +10707,7 @@
       }
     },
     "packages/nube-devtools": {
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@microlink/react-json-view": "^1.31.20",

--- a/packages/nube-devtools/package.json
+++ b/packages/nube-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nube-devtools",
   "displayName": "nube-devtools",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "Tiendanube / Nuvemshop",
   "description": "Chrome DevTools extension for debugging and testing NubeSDK apps with real-time insights.",
   "type": "module",

--- a/packages/nube-devtools/package.json
+++ b/packages/nube-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nube-devtools",
   "displayName": "nube-devtools",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": "Tiendanube / Nuvemshop",
   "description": "Chrome DevTools extension for debugging and testing NubeSDK apps with real-time insights.",
   "type": "module",

--- a/packages/nube-devtools/package.json
+++ b/packages/nube-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nube-devtools",
   "displayName": "nube-devtools",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": "Tiendanube / Nuvemshop",
   "description": "Chrome DevTools extension for debugging and testing NubeSDK apps with real-time insights.",
   "type": "module",

--- a/packages/nube-devtools/tsconfig.json
+++ b/packages/nube-devtools/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/packages/nube-devtools/tsconfig.node.json
+++ b/packages/nube-devtools/tsconfig.node.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node"


### PR DESCRIPTION
## What

Adds an automated Chrome Web Store publish flow for the **NubeSDK DevTools** extension, triggered by `nube-sdk-*` release tags in CircleCI.

## How it works

The workflow runs only on `nube-sdk-*` tags (never on branches) and has three steps:

1. **`upload-devtools-draft`** — installs deps, builds and zips the extension (`npm run zip -w packages/nube-devtools`), uploads the zip to the Chrome Web Store as a **draft** (no `/publish` call), and creates a GitHub release with the zip attached as an asset.
2. **`approval-publish-devtools`** — a manual approval gate before going public.
3. **`publish-devtools-store`** — after approval, promotes the existing draft to public by calling the Chrome Web Store `/publish` endpoint (it does **not** re-upload the zip).

Chrome Web Store auth uses a refresh token exchanged for a short-lived access token. Secrets (`CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`, `CHROME_EXTENSION_ID`, `GITHUB_TOKEN`) come from CircleCI Project Env Vars.

## Other changes

- `.gitignore`: ignore `token.json` and `release.json` (they contain OAuth tokens / API responses).
- `tsconfig.json` / `tsconfig.node.json`: add `ignoreDeprecations: "5.0"` so the DevTools build passes on the current TypeScript.
- `package-lock.json`: refreshed as part of the install.

## Summary by CodeRabbit

* **New Features**
  * Added an automated Chrome Web Store release flow for the DevTools extension.
  * Releases can be uploaded as drafts and published after an approval step.
  * GitHub releases now include the packaged extension artifact.

* **Chores**
  * Excluded release credentials and response artifacts from version control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Chrome Web Store release flow for the DevTools extension, including draft upload and a publish approval gate.
  * Automatically creates GitHub release assets with the packaged extension artifact on tag builds.
* **Chores**
  * Excluded Chrome Web Store publish credential/response artifacts from version control.
* **Style**
  * Reformatted the DevTools package manifest.
  * Updated TypeScript settings to ignore deprecation warnings for the DevTools builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->