### PR TITLE
feat(nube-sdk): add VideoStories component and bump version

### DIFF
--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-jsx",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Library for building JSX interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jsx/src/components.tsx
+++ b/packages/jsx/src/components.tsx
@@ -131,6 +131,8 @@ import type {
 	NubeComponentVideoPlayerProps,
 	NubeComponentVideoRoot,
 	NubeComponentVideoRootProps,
+	NubeComponentVideoStories,
+	NubeComponentVideoStoriesProps,
 	NubeComponentVideoYouTube,
 	NubeComponentVideoYouTubeProps,
 } from "@tiendanube/nube-sdk-types";
@@ -201,6 +203,7 @@ import {
 	toastTitle,
 	videoPlayer,
 	videoRoot,
+	videoStories,
 	videoYouTube,
 } from "@tiendanube/nube-sdk-ui";
 
@@ -501,6 +504,23 @@ export const Video = {
 	Player: VideoPlayer,
 	YouTube: VideoYouTube,
 };
+
+/**
+ * Creates a `VideoStories` component.
+ *
+ * `VideoStories` is a vertical, stories-style player for a sequence of
+ * self-hosted videos (Instagram/WhatsApp-style). It renders inline as a compact
+ * 9:16 card; and can be expanded to a fullscreen overlay. Events (`onOpen`,
+ * `onClose`, `onChange`, `onComplete`, `onError`) are observe-only.
+ *
+ * @param props - The properties for configuring the video stories component.
+ * @returns A `NubeComponentVideoStories` object.
+ */
+export function VideoStories(
+	props: NubeComponentVideoStoriesProps,
+): NubeComponentVideoStories {
+	return videoStories(props);
+}
 
 /**
  * Creates a `Select` component.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.89.1",
+	"version": "0.90.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -945,6 +945,125 @@ export type NubeComponentVideoYouTube = Prettify<
 >;
 
 /* -------------------------------------------------------------------------- */
+/*                        VideoStories Component                              */
+/* -------------------------------------------------------------------------- */
+
+/** A single story in the playlist: a self-hosted video with an optional poster. */
+export type VideoStoriesItem = {
+	/**
+	 * MP4, HLS (`.m3u8`) or DASH (`.mpd`) source. Must be an **absolute**
+	 * https URL (e.g. `https://cdn.example.com/video.mp4`).
+	 * Items with an unsafe URL are dropped before render.
+	 */
+	src: SecurityURL;
+	/** Poster image shown before playback. Must be an absolute https URL. */
+	poster?: SecurityURL;
+};
+
+/** Payload emitted with the `open` VideoStories event. */
+export type NubeComponentVideoStoriesOpenPayload = {
+	/** Index of the story that was active when the overlay opened. */
+	index: number;
+	/** Total number of stories in the playlist. */
+	total: number;
+};
+
+/** Payload emitted with the `close` and `change` VideoStories events. */
+export type NubeComponentVideoStoriesIndexPayload = {
+	/** Index of the active story at the time of the event. */
+	index: number;
+};
+
+/** Payload emitted with the `complete` VideoStories event. */
+export type NubeComponentVideoStoriesCompletePayload = {
+	/** Total number of stories in the playlist. */
+	total: number;
+};
+
+/** Payload emitted with the `error` VideoStories event. */
+export type NubeComponentVideoStoriesErrorPayload = {
+	/** Index of the story that failed to load or play. */
+	index: number;
+};
+
+export type NubeComponentVideoStoriesOpenHandler = NubeComponentEventHandler<
+	"open",
+	NubeComponentVideoStoriesOpenPayload
+>;
+export type NubeComponentVideoStoriesCloseHandler = NubeComponentEventHandler<
+	"close",
+	NubeComponentVideoStoriesIndexPayload
+>;
+export type NubeComponentVideoStoriesChangeHandler = NubeComponentEventHandler<
+	"change",
+	NubeComponentVideoStoriesIndexPayload
+>;
+export type NubeComponentVideoStoriesCompleteHandler =
+	NubeComponentEventHandler<
+		"complete",
+		NubeComponentVideoStoriesCompletePayload
+	>;
+export type NubeComponentVideoStoriesErrorHandler = NubeComponentEventHandler<
+	"error",
+	NubeComponentVideoStoriesErrorPayload
+>;
+
+/**
+ * Properties for `VideoStories` — a vertical, stories-style player for a
+ * sequence of self-hosted videos (Instagram/WhatsApp-style). Plays inline as
+ * a compact card; tapping the card expands to a fullscreen overlay.
+ */
+export type NubeComponentVideoStoriesProps = Prettify<
+	NubeComponentBase & {
+		/** The ordered playlist. */
+		items: VideoStoriesItem[];
+		/** Inline card width in px (renders as a 9:16 card). Defaults to `96`. */
+		width?: number | string;
+		/** Start muted. Defaults to `true` (browser autoplay policy); user can unmute. */
+		startMuted?: boolean;
+		/** Press-and-hold the story to pause; release to resume. Defaults to `true`. */
+		pauseOnHold?: boolean;
+		/**
+		 * Tap the left/right thirds to navigate to the previous/next story
+		 * (both inline and fullscreen). Defaults to `true`.
+		 */
+		tapToNavigate?: boolean;
+		/**
+		 * Advance to the next story when the current one ends. Defaults to `true`;
+		 * when `false`, playback stops on the last frame of each story.
+		 */
+		autoAdvance?: boolean;
+		/**
+		 * After the last story, restart from the first instead of completing.
+		 * Defaults to `false`. Only meaningful together with `autoAdvance`.
+		 */
+		loop?: boolean;
+		style?: NubeComponentStyle;
+		/** Emitted (observe-only) when the fullscreen overlay opens. */
+		onOpen?: NubeComponentVideoStoriesOpenHandler;
+		/** Emitted (observe-only) when the fullscreen overlay closes. */
+		onClose?: NubeComponentVideoStoriesCloseHandler;
+		/** Emitted (observe-only) when the active story changes. */
+		onChange?: NubeComponentVideoStoriesChangeHandler;
+		/** Emitted (observe-only) when the last story finishes. */
+		onComplete?: NubeComponentVideoStoriesCompleteHandler;
+		/** Emitted (observe-only) when a story fails to load or play. */
+		onError?: NubeComponentVideoStoriesErrorHandler;
+		children?: NubeComponentChildren;
+	}
+>;
+
+/**
+ * Represents a `videoStories` component, a stories-style video playlist.
+ */
+export type NubeComponentVideoStories = Prettify<
+	NubeComponentBase &
+		NubeComponentVideoStoriesProps & {
+			type: "videoStories";
+		}
+>;
+
+/* -------------------------------------------------------------------------- */
 /*                           Txt Component                                    */
 /* -------------------------------------------------------------------------- */
 
@@ -2656,6 +2775,7 @@ export type NubeComponent =
 	| NubeComponentVideoRoot
 	| NubeComponentVideoPlayer
 	| NubeComponentVideoYouTube
+	| NubeComponentVideoStories
 	| NubeComponentText
 	| NubeComponentCheckbox
 	| NubeComponentTextarea

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-ui",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Library for building declarative interfaces for NubeSDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/src/components/video-stories.ts
+++ b/packages/ui/src/components/video-stories.ts
@@ -1,0 +1,25 @@
+import type {
+	NubeComponentVideoStories,
+	NubeComponentVideoStoriesProps,
+} from "@tiendanube/nube-sdk-types";
+import { generateInternalId } from "./generateInternalId";
+
+/**
+ * Creates a `videoStories` component.
+ *
+ * `VideoStories` is a vertical, stories-style player for a sequence of
+ * self-hosted videos (MP4, HLS or DASH). It renders inline as a compact 9:16
+ * card; tapping the card expands to a fullscreen overlay. Events (`onOpen`,
+ * `onClose`, `onChange`, `onComplete`, `onError`) are observe-only — they
+ * never gate playback.
+ *
+ * @param props - The properties for configuring the video stories component.
+ * @returns A `NubeComponentVideoStories` object.
+ */
+export const videoStories = (
+	props: NubeComponentVideoStoriesProps,
+): NubeComponentVideoStories => ({
+	type: "videoStories",
+	...props,
+	__internalId: generateInternalId("videoStories", props),
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,6 +8,7 @@ export * from "./components/image";
 export * from "./components/progress";
 export * from "./components/iframe";
 export * from "./components/video";
+export * from "./components/video-stories";
 export * from "./components/text";
 export * from "./components/checkbox";
 export * from "./components/textarea";


### PR DESCRIPTION
This PR adds `VideoStories` component with its types.
Bumps `ui` and `types` package version.

## Related PR
https://github.com/TiendaNube/nube-sdk-internal/pull/260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new self-hosted **video stories** component for playlist-style video playback.
  * Included configurable overlay and interaction behaviors.
  * Added typed event handling for open, close/change, complete, and error states.
  * Exposed the component via both the UI entrypoint and the JSX package.
* **Chores**
  * Bumped versions for the types, UI, and JSX packages (0.89.1→0.90.0, 0.21.0→0.22.0, 0.20.0→0.21.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->