### PR TITLE
feat(types): add CART_OPEN event to SENDABLE_EVENT

### DIFF
--- a/packages/helper/src/lib/render.spec.ts
+++ b/packages/helper/src/lib/render.spec.ts
@@ -85,6 +85,7 @@ const createMockState = (
 			},
 			language: "en",
 			theme: "rio",
+			quick_cart: false,
 		},
 		ui: {
 			slots: {},

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -408,6 +408,9 @@ export type Store = {
 
 	/** The store's theme template (e.g., "recife", "morelia", "rio"). */
 	theme: string;
+
+	/** Whether products can be added to the cart without redirecting to the cart page. */
+	quick_cart: boolean;
 };
 
 type FixedProductListSectionName =

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -16,6 +16,7 @@ export type NubeSDKCustomEvent = `custom:${string}:${string}`;
  * @property {"cart:validate"} CART_VALIDATE - Triggered to validate the current cart state.
  * @property {"cart:add"} CART_ADD - Used to add a cart item.
  * @property {"cart:remove"} CART_REMOVE - Used to remove a cart item.
+ * @property {"cart:open"} CART_OPEN - Used to open the cart.
  * @property {"config:set"} CONFIG_SET - Used to update the SDK configuration.
  * @property {"ui:slot:set"} UI_SLOT_SET - Used to update a UI slot with new content.
  * @property {"shipping:update:label"} SHIPPING_UPDATE_LABEL - Used to update custom labels for shipping options.
@@ -30,6 +31,7 @@ export const SENDABLE_EVENT = {
 	CART_VALIDATE: "cart:validate",
 	CART_ADD: "cart:add",
 	CART_REMOVE: "cart:remove",
+	CART_OPEN: "cart:open",
 	CONFIG_SET: "config:set",
 	UI_SLOT_SET: "ui:slot:set",
 	SHIPPING_UPDATE_LABEL: "shipping:update:label",


### PR DESCRIPTION
## Description

This pull request adds support for a new cart-related event to the SDK event types. The main change is the introduction of the `cart:open` event, which enables opening the cart through the event system.

**Event type additions:**

* Added a new `CART_OPEN` event (`"cart:open"`) to the `SENDABLE_EVENT` object and documented it in the event type definitions. [[1]](diffhunk://#diff-ad6bc4ecb3819475b6e5e49bbc33789617d047270a1aa32a49f0ae5dbabf7749R19) [[2]](diffhunk://#diff-ad6bc4ecb3819475b6e5e49bbc33789617d047270a1aa32a49f0ae5dbabf7749R34)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `cart:open` event in the SDK’s available event catalog.
  * Added support for identifying whether a store enables quick cart actions, allowing products to be added without redirecting to the cart page.
  * The new event is included in the complete set of supported events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->