### PR TITLE
feat(helper): add available slots discovery helpers

### DIFF
--- a/packages/helper/package.json
+++ b/packages/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiendanube/nube-sdk-helper",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Utility functions, type guards, and SDK instance management for NubeSDK apps",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/helper/src/lib/index.ts
+++ b/packages/helper/src/lib/index.ts
@@ -9,3 +9,4 @@ export * from "./render";
 export * from "./selectors";
 export * from "./ui";
 export * from "./utils";
+export * from "./slots";

--- a/packages/helper/src/lib/slots.spec.ts
+++ b/packages/helper/src/lib/slots.spec.ts
@@ -356,6 +356,95 @@ describe("slots", () => {
 		});
 	});
 
+	describe("equivalent section types", () => {
+		it("finds the dynamic section when queried by its static spelling", async () => {
+			const wanted = dynamicSlot(
+				"featured_products",
+				5,
+				"after_dynamic_section",
+			);
+			const payload: SlotsPayload = {
+				static: [],
+				dynamic: [
+					dynamicSlot("featured_products", 2, "after_dynamic_section"),
+					wanted,
+				],
+			};
+
+			const byStaticName = await setup(payload);
+			await expect(
+				byStaticName.slots.afterLastSection("products_featured"),
+			).resolves.toBe(wanted);
+
+			const byDynamicName = await setup(payload);
+			await expect(
+				byDynamicName.slots.afterLastSection("featured_products"),
+			).resolves.toBe(wanted);
+		});
+
+		it("finds the static slot when queried by its dynamic spelling", async () => {
+			const fallback = staticSlot("after_section_products_featured");
+			const { slots } = await setup({ static: [fallback], dynamic: [] });
+
+			await expect(slots.afterLastSection("featured_products")).resolves.toBe(
+				fallback,
+			);
+		});
+
+		it("prefers the queried spelling over its alias among static slots", async () => {
+			const queried = staticSlot("before_section_featured_products");
+			const { slots } = await setup({
+				static: [staticSlot("before_section_products_featured"), queried],
+				dynamic: [],
+			});
+
+			await expect(slots.beforeFirstSection("featured_products")).resolves.toBe(
+				queried,
+			);
+		});
+
+		it("still prefers any dynamic match over an aliased static slot", async () => {
+			const dynamicMatch = dynamicSlot(
+				"featured_products",
+				1,
+				"before_dynamic_section",
+			);
+			const { slots } = await setup({
+				static: [staticSlot("before_section_products_featured")],
+				dynamic: [dynamicMatch],
+			});
+
+			await expect(slots.beforeFirstSection("products_featured")).resolves.toBe(
+				dynamicMatch,
+			);
+		});
+
+		it("does not associate section types outside the alias table", async () => {
+			const { slots } = await setup({
+				static: [staticSlot("before_section_banner")],
+				dynamic: [dynamicSlot("single-shelf", 1, "before_dynamic_section")],
+			});
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await expect(slots.beforeFirstSection("newsletter")).resolves.toBeNull();
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("reports the queried section type when no alias matches", async () => {
+			const { slots } = await setup();
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await expect(
+				slots.afterLastSection("products_featured"),
+			).resolves.toBeNull();
+
+			const error = errorSpy.mock.calls[0]?.[0] as Error;
+			expect(error.message).toBe(
+				"There is no available slot after last products_featured section for app app-123",
+			);
+		});
+	});
+
 	describe("SlotNotFound", () => {
 		it("formats its message from the query description and app id", async () => {
 			const { slots } = await setup();

--- a/packages/helper/src/lib/slots.spec.ts
+++ b/packages/helper/src/lib/slots.spec.ts
@@ -1,0 +1,383 @@
+import type {
+	AvailableSlotsCommands,
+	DynamicSlot,
+	NubeSDK,
+	StaticSlot,
+} from "@tiendanube/nube-sdk-types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockSDK } from "../internal/test-utils.js";
+
+/** The available-slots payload returned by `getAll` / `getStatic` / `getDynamic`. */
+type SlotsPayload = { static: StaticSlot[]; dynamic: DynamicSlot[] };
+
+/** The dynamically-imported `slots` module (fresh per test, see {@link setup}). */
+type SlotsModule = typeof import("./slots.js");
+
+interface GlobalWithAppData {
+	self: { __APP_DATA__: { id: string; script: string } };
+}
+
+/** Builds a `DynamicSlot` for `sectionType` at `sectionIndex`, before or after. */
+function dynamicSlot(
+	sectionType: string,
+	sectionIndex: number,
+	type: DynamicSlot["type"],
+): DynamicSlot {
+	return {
+		type,
+		sectionType,
+		sectionId: `${sectionType}-${sectionIndex}`,
+		sectionIndex,
+		slotId: `${type}_${sectionType}_${sectionIndex}`,
+	} as DynamicSlot;
+}
+
+/** Builds a non-repeatable `StaticSlot` with the given `slotId`. */
+function staticSlot(slotId: string): StaticSlot {
+	return { slotId, pick: null, isRepeatable: false } as StaticSlot;
+}
+
+/**
+ * Resets the module graph (so `slots.ts` starts with its `api` memo cleared),
+ * registers a mock SDK whose available-slots adapter serves `payload`, and
+ * returns the freshly-imported module together with the adapter spy.
+ */
+async function setup(
+	payload: SlotsPayload = { static: [], dynamic: [] },
+): Promise<{
+	slots: SlotsModule;
+	commands: AvailableSlotsCommands;
+	getAvailableSlotsSpy: ReturnType<typeof vi.fn>;
+}> {
+	vi.resetModules();
+	const instance = await import("./instance.js");
+	const slots = await import("./slots.js");
+
+	const commands: AvailableSlotsCommands = {
+		getAll: vi.fn(async () => payload),
+		getStatic: vi.fn(async () => payload.static),
+		getDynamic: vi.fn(async () => payload.dynamic),
+	};
+	const getAvailableSlotsSpy = vi.fn(() => commands);
+	const sdk = {
+		...createMockSDK(),
+		api: {
+			getAvailableSlots: getAvailableSlotsSpy,
+			getCheckout: vi.fn(),
+			getAnalytics: vi.fn(),
+		},
+	} as unknown as NubeSDK;
+
+	instance.setNubeInstance(sdk);
+
+	return { slots, commands, getAvailableSlotsSpy };
+}
+
+describe("slots", () => {
+	beforeEach(() => {
+		(globalThis as unknown as GlobalWithAppData).self = {
+			__APP_DATA__: { id: "app-123", script: "https://cdn.example.com/app.js" },
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("getAvailableSlotsAPI", () => {
+		it("throws when no NubeSDK instance is registered", async () => {
+			vi.resetModules();
+			const slots = await import("./slots.js");
+
+			expect(() => slots.getAvailableSlotsAPI()).toThrow(/setNubeInstance/);
+		});
+
+		it("memoizes the adapter, resolving it only once", async () => {
+			const { slots, commands, getAvailableSlotsSpy } = await setup();
+
+			const first = slots.getAvailableSlotsAPI();
+			const second = slots.getAvailableSlotsAPI();
+
+			expect(first).toBe(commands);
+			expect(second).toBe(commands);
+			expect(getAvailableSlotsSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("bucket getters", () => {
+		it("getAvailableSlots returns both buckets via getAll", async () => {
+			const payload: SlotsPayload = {
+				static: [staticSlot("footer_seals")],
+				dynamic: [dynamicSlot("single-shelf", 1, "before_dynamic_section")],
+			};
+			const { slots, commands } = await setup(payload);
+
+			await expect(slots.getAvailableSlots()).resolves.toEqual(payload);
+			expect(commands.getAll).toHaveBeenCalledTimes(1);
+		});
+
+		it("getStaticSlots returns only the static bucket via getStatic", async () => {
+			const statics = [staticSlot("footer_seals")];
+			const { slots, commands } = await setup({ static: statics, dynamic: [] });
+
+			await expect(slots.getStaticSlots()).resolves.toEqual(statics);
+			expect(commands.getStatic).toHaveBeenCalledTimes(1);
+		});
+
+		it("getDynamicSlots returns only the dynamic bucket via getDynamic", async () => {
+			const dynamics = [
+				dynamicSlot("single-shelf", 1, "before_dynamic_section"),
+			];
+			const { slots, commands } = await setup({
+				static: [],
+				dynamic: dynamics,
+			});
+
+			await expect(slots.getDynamicSlots()).resolves.toEqual(dynamics);
+			expect(commands.getDynamic).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("beforeFirstSection", () => {
+		it("returns the before-slot of the lowest-index matching section", async () => {
+			const wanted = dynamicSlot("single-shelf", 2, "before_dynamic_section");
+			const { slots } = await setup({
+				static: [],
+				dynamic: [
+					dynamicSlot("single-shelf", 5, "before_dynamic_section"),
+					wanted,
+					dynamicSlot("single-shelf", 2, "after_dynamic_section"),
+				],
+			});
+
+			await expect(slots.beforeFirstSection("single-shelf")).resolves.toBe(
+				wanted,
+			);
+		});
+
+		it("finds the section even when it is not the first dynamic section on the page", async () => {
+			const wanted = dynamicSlot("single-shelf", 2, "before_dynamic_section");
+			const { slots } = await setup({
+				static: [],
+				dynamic: [dynamicSlot("banner", 1, "before_dynamic_section"), wanted],
+			});
+
+			await expect(slots.beforeFirstSection("single-shelf")).resolves.toBe(
+				wanted,
+			);
+		});
+
+		it("falls back to the static before_section_${type} slot", async () => {
+			const fallback = staticSlot("before_section_single-shelf");
+			const { slots } = await setup({ static: [fallback], dynamic: [] });
+
+			await expect(slots.beforeFirstSection("single-shelf")).resolves.toBe(
+				fallback,
+			);
+		});
+
+		it("logs SlotNotFound and resolves null when nothing matches", async () => {
+			const { slots } = await setup();
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await expect(
+				slots.beforeFirstSection("single-shelf"),
+			).resolves.toBeNull();
+
+			const error = errorSpy.mock.calls[0]?.[0] as Error;
+			expect(error).toBeInstanceOf(slots.SlotNotFound);
+			expect(error.message).toBe(
+				"There is no available slot before first single-shelf section for app app-123",
+			);
+		});
+	});
+
+	describe("afterFirstSection", () => {
+		it("returns the after-slot of the lowest-index matching section", async () => {
+			const wanted = dynamicSlot("single-shelf", 2, "after_dynamic_section");
+			const { slots } = await setup({
+				static: [],
+				dynamic: [
+					dynamicSlot("single-shelf", 2, "before_dynamic_section"),
+					dynamicSlot("single-shelf", 5, "after_dynamic_section"),
+					wanted,
+				],
+			});
+
+			await expect(slots.afterFirstSection("single-shelf")).resolves.toBe(
+				wanted,
+			);
+		});
+
+		it("falls back to the static after_section_${type} slot", async () => {
+			const fallback = staticSlot("after_section_single-shelf");
+			const { slots } = await setup({ static: [fallback], dynamic: [] });
+
+			await expect(slots.afterFirstSection("single-shelf")).resolves.toBe(
+				fallback,
+			);
+		});
+
+		it("logs SlotNotFound and resolves null when nothing matches", async () => {
+			const { slots } = await setup();
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await expect(slots.afterFirstSection("single-shelf")).resolves.toBeNull();
+
+			const error = errorSpy.mock.calls[0]?.[0] as Error;
+			expect(error.message).toBe(
+				"There is no available slot after first single-shelf section for app app-123",
+			);
+		});
+	});
+
+	describe("beforeLastSection", () => {
+		it("returns the before-slot of the highest-index matching section", async () => {
+			// Regression: two sections of the same type produce four dynamic slots,
+			// so the old `sectionIndex === dynamic.length - 1` check (=== 3) matched
+			// nothing. The last section here is index 5, not 3.
+			const wanted = dynamicSlot("single-shelf", 5, "before_dynamic_section");
+			const { slots } = await setup({
+				static: [],
+				dynamic: [
+					dynamicSlot("single-shelf", 2, "before_dynamic_section"),
+					dynamicSlot("single-shelf", 2, "after_dynamic_section"),
+					wanted,
+					dynamicSlot("single-shelf", 5, "after_dynamic_section"),
+				],
+			});
+
+			await expect(slots.beforeLastSection("single-shelf")).resolves.toBe(
+				wanted,
+			);
+		});
+
+		it("ignores sections of other types when picking the last one", async () => {
+			const wanted = dynamicSlot("single-shelf", 3, "before_dynamic_section");
+			const { slots } = await setup({
+				static: [],
+				dynamic: [wanted, dynamicSlot("banner", 9, "before_dynamic_section")],
+			});
+
+			await expect(slots.beforeLastSection("single-shelf")).resolves.toBe(
+				wanted,
+			);
+		});
+
+		it("falls back to the static before_section_${type} slot", async () => {
+			const fallback = staticSlot("before_section_single-shelf");
+			const { slots } = await setup({ static: [fallback], dynamic: [] });
+
+			await expect(slots.beforeLastSection("single-shelf")).resolves.toBe(
+				fallback,
+			);
+		});
+
+		it("logs SlotNotFound and resolves null when nothing matches", async () => {
+			const { slots } = await setup();
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await expect(slots.beforeLastSection("single-shelf")).resolves.toBeNull();
+
+			const error = errorSpy.mock.calls[0]?.[0] as Error;
+			expect(error.message).toBe(
+				"There is no available slot before last single-shelf section for app app-123",
+			);
+		});
+	});
+
+	describe("afterLastSection", () => {
+		it("returns the after-slot of the highest-index matching section", async () => {
+			const wanted = dynamicSlot("single-shelf", 5, "after_dynamic_section");
+			const { slots } = await setup({
+				static: [],
+				dynamic: [
+					dynamicSlot("single-shelf", 2, "after_dynamic_section"),
+					dynamicSlot("single-shelf", 5, "before_dynamic_section"),
+					wanted,
+				],
+			});
+
+			await expect(slots.afterLastSection("single-shelf")).resolves.toBe(
+				wanted,
+			);
+		});
+
+		it("falls back to the static after_section_${type} slot", async () => {
+			const fallback = staticSlot("after_section_single-shelf");
+			const { slots } = await setup({ static: [fallback], dynamic: [] });
+
+			await expect(slots.afterLastSection("single-shelf")).resolves.toBe(
+				fallback,
+			);
+		});
+
+		it("logs SlotNotFound and resolves null when nothing matches", async () => {
+			const { slots } = await setup();
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			await expect(slots.afterLastSection("single-shelf")).resolves.toBeNull();
+
+			const error = errorSpy.mock.calls[0]?.[0] as Error;
+			expect(error.message).toBe(
+				"There is no available slot after last single-shelf section for app app-123",
+			);
+		});
+	});
+
+	describe("dynamic search precedence", () => {
+		it("prefers a matching dynamic slot over the static fallback", async () => {
+			const dynamicMatch = dynamicSlot(
+				"single-shelf",
+				1,
+				"before_dynamic_section",
+			);
+			const { slots } = await setup({
+				static: [staticSlot("before_section_single-shelf")],
+				dynamic: [dynamicMatch],
+			});
+
+			await expect(slots.beforeFirstSection("single-shelf")).resolves.toBe(
+				dynamicMatch,
+			);
+		});
+
+		it("does not match a dynamic slot of the wrong position", async () => {
+			const fallback = staticSlot("before_section_single-shelf");
+			const { slots } = await setup({
+				static: [fallback],
+				// only an after-slot exists; beforeFirstSection must not return it
+				dynamic: [dynamicSlot("single-shelf", 1, "after_dynamic_section")],
+			});
+
+			await expect(slots.beforeFirstSection("single-shelf")).resolves.toBe(
+				fallback,
+			);
+		});
+	});
+
+	describe("SlotNotFound", () => {
+		it("formats its message from the query description and app id", async () => {
+			const { slots } = await setup();
+
+			const error = new slots.SlotNotFound("before first x section", 42);
+
+			expect(error).toBeInstanceOf(Error);
+			expect(error.message).toBe(
+				"There is no available slot before first x section for app 42",
+			);
+		});
+
+		it("log reads the app id from self.__APP_DATA__.id", async () => {
+			const { slots } = await setup();
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+			slots.SlotNotFound.log("after last y section");
+
+			const error = errorSpy.mock.calls[0]?.[0] as Error;
+			expect(error.message).toBe(
+				"There is no available slot after last y section for app app-123",
+			);
+		});
+	});
+});

--- a/packages/helper/src/lib/slots.ts
+++ b/packages/helper/src/lib/slots.ts
@@ -151,7 +151,10 @@ export async function getStaticSlots() {
  * @example
  * ```typescript
  * const dynamics = await getDynamicSlots();
- * const shelves = dynamics.filter((slot) => slot.sectionType === "single-shelf");
+ * // raw slots carry the section's own name, so no alias resolution happens here
+ * const featured = dynamics.filter(
+ * 	(slot) => slot.sectionType === "featured_products",
+ * );
  * ```
  *
  * @since 0.3.0
@@ -168,6 +171,50 @@ type SectionPosition = "before" | "after";
 type SectionOrder = "first" | "last";
 
 /**
+ * Section types that name the same logical theme section under different
+ * spellings.
+ *
+ * The static slots were named after the section they wrap (`products_featured`)
+ * while the dynamic sections are named after the page data that feeds them
+ * (`featured_products`), so the same section answers to two names depending on
+ * whether the theme renders it as a fixed or as a dynamic section. Each entry
+ * is an equivalence class: every name in it refers to one section, so a query
+ * for any of them must consider all of them.
+ *
+ * Private on purpose — apps keep passing whichever name they know and the
+ * lookup normalizes it. To teach the helpers a new pair, add a group here.
+ */
+const EQUIVALENT_SECTION_TYPES: readonly (readonly string[])[] = [
+	["featured_products", "products_featured"],
+];
+
+/**
+ * Index from a section type to its equivalence class in
+ * {@link EQUIVALENT_SECTION_TYPES}, built once at module load so a query is a
+ * single map lookup.
+ */
+const equivalenceIndex = new Map<string, readonly string[]>(
+	EQUIVALENT_SECTION_TYPES.flatMap((group) =>
+		group.map((sectionType) => [sectionType, group] as const),
+	),
+);
+
+/**
+ * Expands a section type into every name that refers to the same section.
+ *
+ * The queried name always comes first, so static lookups keep preferring the
+ * spelling the app asked for; unknown section types expand to themselves.
+ *
+ * @param sectionType - The theme section type as the app spelled it
+ * @returns The section type followed by its known aliases
+ */
+function getEquivalentSectionTypes(sectionType: string): readonly string[] {
+	const group = equivalenceIndex.get(sectionType);
+	if (!group) return [sectionType];
+	return [sectionType, ...group.filter((alias) => alias !== sectionType)];
+}
+
+/**
  * Shared implementation behind the four section-query helpers.
  *
  * Dynamic sections are searched first: it filters the page's dynamic slots by
@@ -178,7 +225,11 @@ type SectionOrder = "first" | "last";
  * back to the unique static `${position}_section_${sectionType}` slot. When
  * neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
  *
- * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * Both searches run over the section type and its aliases (see
+ * {@link EQUIVALENT_SECTION_TYPES}), so a section that is spelled one way as a
+ * static slot and another as a dynamic one is found under either name.
+ *
+ * @param sectionType - The theme section type (e.g. `"products_featured"`)
  * @param position - Whether to target the slot before or after the section
  * @param order - Whether to target the first or the last section of the type
  */
@@ -189,11 +240,13 @@ async function findSectionSlot(
 ): Promise<QuerySlotResult> {
 	const slots = await getAvailableSlots();
 	const dynamicType: DynamicSlot["type"] = `${position}_dynamic_section`;
+	const sectionTypes = getEquivalentSectionTypes(sectionType);
 
 	// find in dynamic slots: pick the lowest/highest sectionIndex among the
 	// matching sections rather than assuming a fixed index.
 	const candidates = slots.dynamic.filter(
-		(slot) => slot.sectionType === sectionType && slot.type === dynamicType,
+		(slot) =>
+			sectionTypes.includes(slot.sectionType) && slot.type === dynamicType,
 	);
 
 	if (candidates.length > 0) {
@@ -209,12 +262,14 @@ async function findSectionSlot(
 		return dynamicSection;
 	}
 
-	// find in static slots (unique, so the same slot serves first and last)
-	const staticSection = slots.static.find(
-		(slot) => slot.slotId === `${position}_section_${sectionType}`,
-	);
-
-	if (staticSection) return staticSection;
+	// find in static slots (unique, so the same slot serves first and last),
+	// trying the queried spelling before its aliases
+	for (const type of sectionTypes) {
+		const staticSection = slots.static.find(
+			(slot) => slot.slotId === `${position}_section_${type}`,
+		);
+		if (staticSection) return staticSection;
+	}
 
 	SlotNotFound.log(`${position} ${order} ${sectionType} section`);
 	return null;
@@ -227,7 +282,7 @@ async function findSectionSlot(
  * that type, it falls back to the static `before_section_${sectionType}` slot.
  * When neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
  *
- * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @param sectionType - The theme section type (e.g. `"products_featured"`)
  * @returns A promise resolving to the matching slot, or `null` when the page
  * has no such section
  * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
@@ -235,7 +290,7 @@ async function findSectionSlot(
  * @example
  * ```typescript
  * // `ui.render` accepts the promise directly and skips rendering on `null`.
- * ui.render(beforeFirstSection("single-shelf"), component);
+ * ui.render(beforeFirstSection("products_featured"), component);
  * ```
  *
  * @since 0.3.0
@@ -253,14 +308,14 @@ export function beforeFirstSection(
  * that type, it falls back to the static `after_section_${sectionType}` slot.
  * When neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
  *
- * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @param sectionType - The theme section type (e.g. `"products_featured"`)
  * @returns A promise resolving to the matching slot, or `null` when the page
  * has no such section
  * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
  *
  * @example
  * ```typescript
- * const slot = await afterFirstSection("single-shelf");
+ * const slot = await afterFirstSection("products_featured");
  * if (slot) ui.render(slot, component);
  * ```
  *
@@ -280,14 +335,14 @@ export function afterFirstSection(
  * (which is unique, so it is the same slot {@link beforeFirstSection} returns).
  * When neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
  *
- * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @param sectionType - The theme section type (e.g. `"products_featured"`)
  * @returns A promise resolving to the matching slot, or `null` when the page
  * has no such section
  * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
  *
  * @example
  * ```typescript
- * ui.render(beforeLastSection("single-shelf"), component);
+ * ui.render(beforeLastSection("products_featured"), component);
  * ```
  *
  * @since 0.3.0
@@ -306,14 +361,14 @@ export function beforeLastSection(
  * (which is unique, so it is the same slot {@link afterFirstSection} returns).
  * When neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
  *
- * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @param sectionType - The theme section type (e.g. `"products_featured"`)
  * @returns A promise resolving to the matching slot, or `null` when the page
  * has no such section
  * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
  *
  * @example
  * ```typescript
- * ui.render(afterLastSection("single-shelf"), component);
+ * ui.render(afterLastSection("products_featured"), component);
  * ```
  *
  * @since 0.3.0

--- a/packages/helper/src/lib/slots.ts
+++ b/packages/helper/src/lib/slots.ts
@@ -1,0 +1,325 @@
+/**
+ * @fileoverview Available-slots discovery helpers for NubeSDK
+ *
+ * The slots present on a page are not fixed: dynamic theme sections can be
+ * added, removed or reordered by the store owner, so the same logical slot may
+ * exist many times (or not at all). This module wraps
+ * `nube.api.getAvailableSlots()` to answer the questions an app actually has —
+ * "which slots exist here?" and "where is the first/last section of this
+ * type?" — returning a slot ready to be passed to `ui.render`.
+ */
+
+import type {
+	AvailableSlotsCommands,
+	DynamicSlot,
+	Nullable,
+	StaticSlot,
+} from "@tiendanube/nube-sdk-types";
+import { getNubeInstance } from "./instance";
+
+/**
+ * The result of a slot query.
+ *
+ * A `DynamicSlot` when the section was found among the page's dynamic
+ * sections, a `StaticSlot` when it was found as a fixed theme slot, or `null`
+ * when the page exposes neither.
+ *
+ * @since 0.3.0
+ */
+export type QuerySlotResult = StaticSlot | DynamicSlot | null;
+
+/**
+ * The memoized available-slots adapter, resolved on first use by
+ * {@link getAvailableSlotsAPI}. `null` until then.
+ */
+let api: Nullable<AvailableSlotsCommands> = null;
+
+/**
+ * Error describing a slot query that matched nothing on the current page.
+ *
+ * The query helpers do not throw it: they log it through {@link SlotNotFound.log}
+ * and return `null`, so a missing slot degrades into "nothing rendered"
+ * instead of breaking the app.
+ *
+ * @since 0.3.0
+ */
+export class SlotNotFound extends Error {
+	/**
+	 * @param queryDescription - Human-readable description of the query that
+	 * failed (e.g. `"before first product-list section"`)
+	 * @param appid - The id of the app that ran the query
+	 */
+	constructor(queryDescription: string, appid: string | number) {
+		super(`There is no available slot ${queryDescription} for app ${appid}`);
+	}
+
+	/**
+	 * Logs a `SlotNotFound` for the current app to the console.
+	 *
+	 * Reads the app id from `self.__APP_DATA__.id`, so it is meant to run inside
+	 * the NubeSDK Web Worker runtime.
+	 *
+	 * @param queryDescription - Human-readable description of the query that
+	 * failed
+	 *
+	 * @example
+	 * ```typescript
+	 * SlotNotFound.log("before first product-list section");
+	 * // Error: There is no available slot before first product-list section for app 123
+	 * ```
+	 */
+	static log(queryDescription: string) {
+		console.error(new SlotNotFound(queryDescription, self.__APP_DATA__.id));
+	}
+}
+
+/**
+ * Gets the available-slots adapter from the registered NubeSDK instance.
+ *
+ * The adapter is resolved once and memoized for the lifetime of the app, so
+ * repeated queries reuse the same command channel.
+ *
+ * @returns The available-slots adapter (`nube.api.getAvailableSlots()`)
+ * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
+ *
+ * @example
+ * ```typescript
+ * const slotsApi = getAvailableSlotsAPI();
+ * const dynamics = await slotsApi.getDynamic();
+ * ```
+ *
+ * @since 0.3.0
+ */
+export function getAvailableSlotsAPI() {
+	if (api === null) {
+		api = getNubeInstance().api.getAvailableSlots();
+	}
+	return api;
+}
+
+/**
+ * Gets every slot available on the current page, split by kind.
+ *
+ * @returns A promise resolving to the page's `static` and `dynamic` slots
+ * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
+ *
+ * @example
+ * ```typescript
+ * const { static: statics, dynamic: dynamics } = await getAvailableSlots();
+ * console.log(statics.length, dynamics.length);
+ * ```
+ *
+ * @since 0.3.0
+ */
+export async function getAvailableSlots() {
+	const slots = await getAvailableSlotsAPI().getAll();
+	return slots;
+}
+
+/**
+ * Gets only the static slots available on the current page.
+ *
+ * Static slots are the theme's fixed injection points, addressable by their
+ * `slotId` alone.
+ *
+ * @returns A promise resolving to the page's static slots
+ * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
+ *
+ * @example
+ * ```typescript
+ * const statics = await getStaticSlots();
+ * const hasFooterSeals = statics.some((slot) => slot.slotId === "footer_seals");
+ * ```
+ *
+ * @since 0.3.0
+ */
+export async function getStaticSlots() {
+	const slots = await getAvailableSlotsAPI().getStatic();
+	return slots;
+}
+
+/**
+ * Gets only the dynamic slots available on the current page.
+ *
+ * Each dynamic slot carries the coordinates of its theme section
+ * (`sectionType`, `sectionId`, `sectionIndex`), which is what lets an app pick
+ * a specific instance when a section repeats.
+ *
+ * @returns A promise resolving to the page's dynamic slots
+ * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
+ *
+ * @example
+ * ```typescript
+ * const dynamics = await getDynamicSlots();
+ * const shelves = dynamics.filter((slot) => slot.sectionType === "single-shelf");
+ * ```
+ *
+ * @since 0.3.0
+ */
+export async function getDynamicSlots() {
+	const slots = await getAvailableSlotsAPI().getDynamic();
+	return slots;
+}
+
+/** Whether a query targets the slot before or after a section. */
+type SectionPosition = "before" | "after";
+
+/** Whether a query targets the first or the last section of a type. */
+type SectionOrder = "first" | "last";
+
+/**
+ * Shared implementation behind the four section-query helpers.
+ *
+ * Dynamic sections are searched first: it filters the page's dynamic slots by
+ * `sectionType` and position, then picks the one with the lowest
+ * (`"first"`) or highest (`"last"`) `sectionIndex`. This is robust to how many
+ * sections of the type exist and to their position among the page's other
+ * dynamic sections. When the theme has no matching dynamic section, it falls
+ * back to the unique static `${position}_section_${sectionType}` slot. When
+ * neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
+ *
+ * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @param position - Whether to target the slot before or after the section
+ * @param order - Whether to target the first or the last section of the type
+ */
+async function findSectionSlot(
+	sectionType: string,
+	position: SectionPosition,
+	order: SectionOrder,
+): Promise<QuerySlotResult> {
+	const slots = await getAvailableSlots();
+	const dynamicType: DynamicSlot["type"] = `${position}_dynamic_section`;
+
+	// find in dynamic slots: pick the lowest/highest sectionIndex among the
+	// matching sections rather than assuming a fixed index.
+	const candidates = slots.dynamic.filter(
+		(slot) => slot.sectionType === sectionType && slot.type === dynamicType,
+	);
+
+	if (candidates.length > 0) {
+		const dynamicSection = candidates.reduce((selected, slot) =>
+			order === "first"
+				? slot.sectionIndex < selected.sectionIndex
+					? slot
+					: selected
+				: slot.sectionIndex > selected.sectionIndex
+					? slot
+					: selected,
+		);
+		return dynamicSection;
+	}
+
+	// find in static slots (unique, so the same slot serves first and last)
+	const staticSection = slots.static.find(
+		(slot) => slot.slotId === `${position}_section_${sectionType}`,
+	);
+
+	if (staticSection) return staticSection;
+
+	SlotNotFound.log(`${position} ${order} ${sectionType} section`);
+	return null;
+}
+
+/**
+ * Finds the slot placed right before the first section of the given type.
+ *
+ * Dynamic sections are searched first; if the theme has no dynamic section of
+ * that type, it falls back to the static `before_section_${sectionType}` slot.
+ * When neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
+ *
+ * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @returns A promise resolving to the matching slot, or `null` when the page
+ * has no such section
+ * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
+ *
+ * @example
+ * ```typescript
+ * // `ui.render` accepts the promise directly and skips rendering on `null`.
+ * ui.render(beforeFirstSection("single-shelf"), component);
+ * ```
+ *
+ * @since 0.3.0
+ */
+export function beforeFirstSection(
+	sectionType: string,
+): Promise<QuerySlotResult> {
+	return findSectionSlot(sectionType, "before", "first");
+}
+
+/**
+ * Finds the slot placed right after the first section of the given type.
+ *
+ * Dynamic sections are searched first; if the theme has no dynamic section of
+ * that type, it falls back to the static `after_section_${sectionType}` slot.
+ * When neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
+ *
+ * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @returns A promise resolving to the matching slot, or `null` when the page
+ * has no such section
+ * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
+ *
+ * @example
+ * ```typescript
+ * const slot = await afterFirstSection("single-shelf");
+ * if (slot) ui.render(slot, component);
+ * ```
+ *
+ * @since 0.3.0
+ */
+export function afterFirstSection(
+	sectionType: string,
+): Promise<QuerySlotResult> {
+	return findSectionSlot(sectionType, "after", "first");
+}
+
+/**
+ * Finds the slot placed right before the last section of the given type.
+ *
+ * Dynamic sections are searched first; if the theme has no matching dynamic
+ * section, it falls back to the static `before_section_${sectionType}` slot
+ * (which is unique, so it is the same slot {@link beforeFirstSection} returns).
+ * When neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
+ *
+ * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @returns A promise resolving to the matching slot, or `null` when the page
+ * has no such section
+ * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
+ *
+ * @example
+ * ```typescript
+ * ui.render(beforeLastSection("single-shelf"), component);
+ * ```
+ *
+ * @since 0.3.0
+ */
+export function beforeLastSection(
+	sectionType: string,
+): Promise<QuerySlotResult> {
+	return findSectionSlot(sectionType, "before", "last");
+}
+
+/**
+ * Finds the slot placed right after the last section of the given type.
+ *
+ * Dynamic sections are searched first; if the theme has no matching dynamic
+ * section, it falls back to the static `after_section_${sectionType}` slot
+ * (which is unique, so it is the same slot {@link afterFirstSection} returns).
+ * When neither exists, it logs a {@link SlotNotFound} and resolves to `null`.
+ *
+ * @param sectionType - The theme section type (e.g. `"single-shelf"`)
+ * @returns A promise resolving to the matching slot, or `null` when the page
+ * has no such section
+ * @throws If no NubeSDK instance was registered (see `setNubeInstance`)
+ *
+ * @example
+ * ```typescript
+ * ui.render(afterLastSection("single-shelf"), component);
+ * ```
+ *
+ * @since 0.3.0
+ */
+export function afterLastSection(
+	sectionType: string,
+): Promise<QuerySlotResult> {
+	return findSectionSlot(sectionType, "after", "last");
+}

--- a/packages/helper/src/lib/slots.ts
+++ b/packages/helper/src/lib/slots.ts
@@ -184,9 +184,33 @@ type SectionOrder = "first" | "last";
  * Private on purpose — apps keep passing whichever name they know and the
  * lookup normalizes it. To teach the helpers a new pair, add a group here.
  */
-const EQUIVALENT_SECTION_TYPES: readonly (readonly string[])[] = [
+const EQUIVALENT_SECTION_TYPES = [
 	["featured_products", "products_featured"],
-];
+] as const;
+
+/**
+ * Section types the SDK knows about: the static section-boundary slots the
+ * theme exposes, plus the equivalence aliases (see
+ * {@link EQUIVALENT_SECTION_TYPES}, kept derived so the table stays the single
+ * source of truth).
+ */
+type KnownSectionType =
+	| "newsletter"
+	| "products_sale"
+	| "products_new"
+	| "products_featured"
+	| (typeof EQUIVALENT_SECTION_TYPES)[number][number];
+
+/**
+ * A theme section type.
+ *
+ * Known section types (`newsletter`, `products_featured`, …) are surfaced as
+ * editor autocomplete, while any other string is still accepted to support
+ * custom and dynamic sections whose names are only known at runtime.
+ *
+ * @since 0.3.0
+ */
+export type SectionType = KnownSectionType | (string & {});
 
 /**
  * Index from a section type to its equivalence class in
@@ -234,7 +258,7 @@ function getEquivalentSectionTypes(sectionType: string): readonly string[] {
  * @param order - Whether to target the first or the last section of the type
  */
 async function findSectionSlot(
-	sectionType: string,
+	sectionType: SectionType,
 	position: SectionPosition,
 	order: SectionOrder,
 ): Promise<QuerySlotResult> {
@@ -296,7 +320,7 @@ async function findSectionSlot(
  * @since 0.3.0
  */
 export function beforeFirstSection(
-	sectionType: string,
+	sectionType: SectionType,
 ): Promise<QuerySlotResult> {
 	return findSectionSlot(sectionType, "before", "first");
 }
@@ -322,7 +346,7 @@ export function beforeFirstSection(
  * @since 0.3.0
  */
 export function afterFirstSection(
-	sectionType: string,
+	sectionType: SectionType,
 ): Promise<QuerySlotResult> {
 	return findSectionSlot(sectionType, "after", "first");
 }
@@ -348,7 +372,7 @@ export function afterFirstSection(
  * @since 0.3.0
  */
 export function beforeLastSection(
-	sectionType: string,
+	sectionType: SectionType,
 ): Promise<QuerySlotResult> {
 	return findSectionSlot(sectionType, "before", "last");
 }
@@ -374,7 +398,7 @@ export function beforeLastSection(
  * @since 0.3.0
  */
 export function afterLastSection(
-	sectionType: string,
+	sectionType: SectionType,
 ): Promise<QuerySlotResult> {
 	return findSectionSlot(sectionType, "after", "last");
 }

--- a/packages/helper/src/lib/ui.spec.ts
+++ b/packages/helper/src/lib/ui.spec.ts
@@ -1,5 +1,9 @@
-import type { NubeSDK } from "@tiendanube/nube-sdk-types";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+	DynamicSlot,
+	NubeSDK,
+	StaticSlot,
+} from "@tiendanube/nube-sdk-types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockSDK } from "../internal/test-utils.js";
 import { clearNubeInstance, setNubeInstance } from "./instance.js";
 import { ui } from "./ui.js";
@@ -14,6 +18,7 @@ describe("ui", () => {
 
 	afterEach(() => {
 		clearNubeInstance();
+		vi.restoreAllMocks();
 	});
 
 	describe("showToast", () => {
@@ -42,10 +47,75 @@ describe("ui", () => {
 		expect(sdk.clearSlot).toHaveBeenCalledWith("corner_top_left");
 	});
 
-	it("render delegates to the instance", () => {
+	describe("render", () => {
 		const component = { type: "txt" as const, children: "hi" };
-		ui.render("before_main_content", component);
-		expect(sdk.render).toHaveBeenCalledWith("before_main_content", component);
+		const staticSlot = {
+			slotId: "footer_seals",
+			pick: null,
+			isRepeatable: false,
+		} as StaticSlot;
+		const dynamicSlot = {
+			type: "before_dynamic_section",
+			sectionType: "single-shelf",
+			sectionId: "single-shelf-1",
+			sectionIndex: 1,
+			slotId: "before_dynamic_section_single-shelf_1",
+		} as DynamicSlot;
+
+		it("delegates a slot name to the instance", () => {
+			ui.render("before_main_content", component);
+			expect(sdk.render).toHaveBeenCalledWith("before_main_content", component);
+		});
+
+		it("delegates a StaticSlot object to the instance", () => {
+			ui.render(staticSlot, component);
+			expect(sdk.render).toHaveBeenCalledWith(staticSlot, component);
+		});
+
+		it("delegates a DynamicSlot object to the instance", () => {
+			ui.render(dynamicSlot, component);
+			expect(sdk.render).toHaveBeenCalledWith(dynamicSlot, component);
+		});
+
+		it("renders the slot a resolved query promise yields", async () => {
+			ui.render(Promise.resolve(dynamicSlot), component);
+
+			await vi.waitFor(() =>
+				expect(sdk.render).toHaveBeenCalledWith(dynamicSlot, component),
+			);
+		});
+
+		it("does not render when the query promise resolves to null", async () => {
+			ui.render(Promise.resolve(null), component);
+
+			// flush microtasks so the promise chain settles
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(sdk.render).not.toHaveBeenCalled();
+		});
+
+		it("logs and swallows a rejected query promise instead of crashing", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const failure = new Error("slot lookup failed");
+
+			// must not throw synchronously
+			expect(() => ui.render(Promise.reject(failure), component)).not.toThrow();
+
+			await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(failure));
+			expect(sdk.render).not.toHaveBeenCalled();
+		});
+
+		it("logs when the instance render throws inside the promise branch", async () => {
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+			const failure = new Error("render blew up");
+			(sdk.render as ReturnType<typeof vi.fn>).mockImplementation(() => {
+				throw failure;
+			});
+
+			ui.render(Promise.resolve(dynamicSlot), component);
+
+			await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(failure));
+		});
 	});
 
 	describe("renderAll", () => {

--- a/packages/helper/src/lib/ui.ts
+++ b/packages/helper/src/lib/ui.ts
@@ -1,9 +1,13 @@
 import type {
+	DynamicSlot,
 	NubeComponent,
 	NubeSDKState,
+	StaticSlot,
 	UISlotArg,
 } from "@tiendanube/nube-sdk-types";
 import { getNubeInstance } from "./instance";
+import type { QuerySlotResult } from "./slots";
+import { isPromise } from "./utils";
 
 /**
  * Visual variants supported by {@link UIHelper.showToast}.
@@ -26,10 +30,13 @@ export type RenderableComponent =
 export type UIHelper = {
 	showToast: (message: string, variant?: ToastVariant) => void;
 	clear: <const TSlot extends string>(slot: UISlotArg<TSlot>) => void;
-	render: <const TSlot extends string>(
-		slot: UISlotArg<TSlot>,
-		component: RenderableComponent,
-	) => void;
+	render: {
+		<const TSlot extends string>(
+			slot: UISlotArg<TSlot> | StaticSlot | DynamicSlot,
+			component: RenderableComponent,
+		): void;
+		(slot: Promise<QuerySlotResult>, component: RenderableComponent): void;
+	};
 	renderAll: <const TSlot extends string>(
 		slots: UISlotArg<TSlot>[],
 		component: RenderableComponent,
@@ -59,10 +66,22 @@ export const ui: Readonly<UIHelper> = Object.freeze({
 	},
 
 	render<const TSlot extends string>(
-		slot: UISlotArg<TSlot>,
+		slot:
+			| UISlotArg<TSlot>
+			| StaticSlot
+			| DynamicSlot
+			| Promise<QuerySlotResult>,
 		component: RenderableComponent,
 	) {
-		getNubeInstance().render<TSlot>(slot, component);
+		isPromise<QuerySlotResult>(slot)
+			? slot
+					.then(
+						(resolved) =>
+							resolved !== null &&
+							getNubeInstance().render<TSlot>(resolved, component),
+					)
+					.catch((error) => console.error(error))
+			: getNubeInstance().render<TSlot>(slot, component);
 	},
 
 	// Render the same component across multiple slots in a single call.

--- a/packages/helper/src/lib/utils.ts
+++ b/packages/helper/src/lib/utils.ts
@@ -124,3 +124,7 @@ export function throttle<T extends (...args: never[]) => unknown>(
 		}
 	};
 }
+
+export function isPromise<T>(value: unknown): value is Promise<T> {
+	return typeof value === "object" && value !== null && "then" in value;
+}

--- a/packages/helper/tsconfig.json
+++ b/packages/helper/tsconfig.json
@@ -15,7 +15,7 @@
     ],
     "module": "esnext",
     "moduleDetection": "force",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noUncheckedIndexedAccess": true,
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## What & why

The slots available on a page aren't fixed. Dynamic theme sections can be added, removed or reordered by the store owner, so the same logical slot may exist multiple times, in a different position, or not at all. On top of that, the same section is sometimes exposed under different names as a **static** slot vs. a **dynamic** one (e.g. `after_section_products_featured` vs. `after_dynamic_section_featured_products`), which forces apps to hardcode slot names and guess per-theme.

This PR adds a slot-discovery layer to `@tiendanube/nube-sdk-helper` on top of `nube.api.getAvailableSlots()`, so apps can ask **"which slots exist here?"** and **"where is the first/last section of this type?"** and get back a slot that's ready for `ui.render`, or `null` when nothing matches.

## What's included

### Discovery helpers

* `getAvailableSlots()` - every slot on the current page, split into `{ static, dynamic }`.
* `getStaticSlots()` - only the theme's fixed injection points (addressable by `slotId`).
* `getDynamicSlots()` - only dynamic slots, each carrying its section coordinates (`sectionType`, `sectionId`, `sectionIndex`).

### Equivalent section-type aliases

A private `EQUIVALENT_SECTION_TYPES` table treats spellings of the same section as one  <br>(currently `featured_products` <-> `products_featured`).  <br>Queries run over the type **and** its aliases, trying the spelling the app asked for first, so a section named one way as a static slot and another as a dynamic one is found under either name. New pairs are taught by adding a group to the table.

## How to use

```tsx
import {
  ui,
  afterLastSection,
  beforeFirstSection,
  setNubeInstance,
} from "@tiendanube/nube-sdk-helper";

import { Text } from "@tiendanube/nube-sdk-jsx";

function Component() {
  return (<Text>Hello</Text>);
}

export function App(nube: NubeSDK) {
  setNubeInstance(nube);
  
  ui.render(beforeFirstSection("newsletter"), <Component/>);
  ui.render(afterLastSection("newsletter"), <Component/>);
}
```

## Related issues

* TiendaNube/nube-sdk#400
  * resolves `products_featured` / `featured_products` consistently across themes (Ipanema exposes it as a dynamic slot); the alias table + dynamic-first lookup make `afterLastSection("products_featured")` land on the right slot without per-theme guessing.
* TiendaNube/nube-sdk#245
  * apps can discover the sections a store owner added via the Theme Designer and render after the chosen one, instead of falling back to a fixed slot like `before_footer`.

## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added helpers to discover available static and dynamic slots.
  * Added section boundary queries with dynamic selection and static fallback.
  * Enhanced UI rendering to accept slot objects and asynchronous slot results.
  * Added support for equivalent section-type aliases.
* **Bug Fixes**
  * Missing slots now return `null` with clear diagnostics.
  * Async rendering handles rejected results without crashing.
* **Tests**
  * Expanded coverage for slot discovery, selection, aliases, and async rendering.
* **Chores**
  * Bumped the helper package version to `0.3.0`.