### PR TITLE
chore(deps): update package versions in create-nube-app templates

### DIFF
--- a/packages/create-nube-app/package.json
+++ b/packages/create-nube-app/package.json
@@ -3,7 +3,7 @@
 	"description": "Create Nube App",
 	"author": "Tiendanube / Nuvemshop",
 	"license": "MIT",
-	"version": "0.26.0",
+	"version": "0.27.0",
 	"bin": {
 		"create-nube-app": "dist/index.js"
 	},
@@ -25,11 +25,5 @@
 		"tsup": "^8.4.0",
 		"typescript": "^5.6.2"
 	},
-	"files": [
-		"./dist",
-		"README.md",
-		"CHANGELOG.md",
-		"LICENSE",
-		"./templates"
-	]
+	"files": ["./dist", "README.md", "CHANGELOG.md", "LICENSE", "./templates"]
 }

--- a/packages/create-nube-app/templates/minimal-ui-jsx/package.json
+++ b/packages/create-nube-app/templates/minimal-ui-jsx/package.json
@@ -14,9 +14,9 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-ui": "^0.19.0",
-		"@tiendanube/nube-sdk-jsx": "^0.18.0",
-		"@tiendanube/nube-sdk-types": "^0.81.0",
+		"@tiendanube/nube-sdk-ui": "^0.22.1",
+		"@tiendanube/nube-sdk-jsx": "^0.21.0",
+		"@tiendanube/nube-sdk-types": "^0.90.0",
 		"@tiendanube/nube-sdk-helper": "^0.2.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",

--- a/packages/create-nube-app/templates/minimal-ui-jsx/package.json
+++ b/packages/create-nube-app/templates/minimal-ui-jsx/package.json
@@ -16,7 +16,7 @@
 		"@biomejs/biome": "^1.9.4",
 		"@tiendanube/nube-sdk-ui": "^0.22.1",
 		"@tiendanube/nube-sdk-jsx": "^0.21.0",
-		"@tiendanube/nube-sdk-types": "^0.90.0",
+		"@tiendanube/nube-sdk-types": "^0.91.0",
 		"@tiendanube/nube-sdk-helper": "^0.2.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",

--- a/packages/create-nube-app/templates/minimal-ui/package.json
+++ b/packages/create-nube-app/templates/minimal-ui/package.json
@@ -14,8 +14,8 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-ui": "^0.19.0",
-		"@tiendanube/nube-sdk-types": "^0.81.0",
+		"@tiendanube/nube-sdk-ui": "^0.22.1",
+		"@tiendanube/nube-sdk-types": "^0.90.0",
 		"@tiendanube/nube-sdk-helper": "^0.2.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",

--- a/packages/create-nube-app/templates/minimal-ui/package.json
+++ b/packages/create-nube-app/templates/minimal-ui/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@tiendanube/nube-sdk-ui": "^0.22.1",
-		"@tiendanube/nube-sdk-types": "^0.90.0",
+		"@tiendanube/nube-sdk-types": "^0.91.0",
 		"@tiendanube/nube-sdk-helper": "^0.2.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",

--- a/packages/create-nube-app/templates/minimal/package.json
+++ b/packages/create-nube-app/templates/minimal/package.json
@@ -13,7 +13,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-types": "^0.90.0",
+		"@tiendanube/nube-sdk-types": "^0.91.0",
 		"@tiendanube/nube-sdk-helper": "^0.2.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",

--- a/packages/create-nube-app/templates/minimal/package.json
+++ b/packages/create-nube-app/templates/minimal/package.json
@@ -13,7 +13,7 @@
 	"author": "Tiendanube / Nuvemshop",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@tiendanube/nube-sdk-types": "^0.81.0",
+		"@tiendanube/nube-sdk-types": "^0.90.0",
 		"@tiendanube/nube-sdk-helper": "^0.2.0",
 		"@vitest/coverage-v8": "^3.0.9",
 		"concurrently": "^9.1.2",


### PR DESCRIPTION
This pull request updates the `create-nube-app` package and its templates to use the latest versions of the Tiendanube SDK dependencies, and bumps the main package version to 0.27.0. The changes help ensure new projects generated with these templates use the most recent SDK features and bug fixes.

Dependency updates:

* Updated `@tiendanube/nube-sdk-ui`, `@tiendanube/nube-sdk-jsx`, and `@tiendanube/nube-sdk-types` to their latest versions in the `minimal-ui-jsx` template (`package.json`).
* Updated `@tiendanube/nube-sdk-ui` and `@tiendanube/nube-sdk-types` to their latest versions in the `minimal-ui` template (`package.json`).
* Updated `@tiendanube/nube-sdk-types` to the latest version in the `minimal` template (`package.json`).

Package versioning and metadata:

* Bumped `create-nube-app` package version from 0.26.0 to 0.27.0 in `package.json`.
* Minor formatting change to the `files` array in `package.json` (no functional impact).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Released an updated version of the app creation tool.
  - Refreshed starter templates to support the latest SDK capabilities.
  - Updated minimal, minimal UI, and minimal UI JSX templates for improved compatibility and a smoother project setup experience.
  - Improved the generated project foundation so newly created apps can take advantage of current platform features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->