### PR TITLE
feat(types): support pseudo-class component styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10778,7 +10778,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.92.0",
+      "version": "0.94.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.93.0",
+	"version": "0.94.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -119,10 +119,22 @@ type EnhancedCSSProperties = {
 };
 
 /**
+ * Interactive states supported by Nube component styles.
+ */
+export type NubeComponentStylePseudoClass =
+	| ":active"
+	| ":focus"
+	| ":focus-visible"
+	| ":hover";
+
+/**
  * Define named styles for Nube components.
  * This type combines CSS properties with theme-aware values and Size types for layout properties.
  */
-export type NubeComponentStyle = Partial<EnhancedCSSProperties>;
+export type NubeComponentStyle = Partial<EnhancedCSSProperties> &
+	Partial<
+		Record<NubeComponentStylePseudoClass, Partial<EnhancedCSSProperties>>
+	>;
 
 /* -------------------------------------------------------------------------- */
 /*                            Box Component                                   */

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -130,6 +130,7 @@ export type NubeComponentStylePseudoClass =
 /**
  * Define named styles for Nube components.
  * This type combines CSS properties with theme-aware values and Size types for layout properties.
+ * In StyleSheet.create, use colon-only pseudo-class keys such as `:hover`; the parent selector is implicit.
  */
 export type NubeComponentStyle = Partial<EnhancedCSSProperties> &
 	Partial<

--- a/packages/ui/src/styles/StyleSheet.spec.ts
+++ b/packages/ui/src/styles/StyleSheet.spec.ts
@@ -23,6 +23,9 @@ describe("StyleSheet", () => {
 				":hover": {
 					backgroundColor: new ThemeColor("primary").opacity(50),
 				},
+				":focus": {
+					outline: "none",
+				},
 				":focus-visible": {
 					outline: "2px solid currentColor",
 				},
@@ -39,6 +42,7 @@ describe("StyleSheet", () => {
 			expect(styles.container[":hover"].backgroundColor).toBe(
 				"var(--primary-opacity-50)",
 			);
+			expect(styles.container[":focus"].outline).toBe("none");
 			expect(styles.container[":focus-visible"].outline).toBe(
 				"2px solid currentColor",
 			);

--- a/packages/ui/src/styles/StyleSheet.spec.ts
+++ b/packages/ui/src/styles/StyleSheet.spec.ts
@@ -1,3 +1,4 @@
+import type { NubeComponentStyle } from "@tiendanube/nube-sdk-types";
 import { describe, expect, it } from "vitest";
 import { StyleSheet } from "./StyleSheet";
 import { ThemeColor } from "./ThemeColor";
@@ -17,19 +18,31 @@ describe("StyleSheet", () => {
 		});
 
 		it("should handle nested style objects", () => {
-			const styles = StyleSheet.create({
-				container: {
-					backgroundColor: new ThemeColor("primary"),
-					":hover": {
-						backgroundColor: new ThemeColor("primary").opacity(50),
-					},
+			const container = {
+				backgroundColor: new ThemeColor("primary"),
+				":hover": {
+					backgroundColor: new ThemeColor("primary").opacity(50),
 				},
+				":focus-visible": {
+					outline: "2px solid currentColor",
+				},
+				":active": {
+					transform: "translateY(1px)",
+				},
+			} satisfies NubeComponentStyle;
+
+			const styles = StyleSheet.create({
+				container,
 			});
 
 			expect(styles.container.backgroundColor).toBe("var(--primary)");
 			expect(styles.container[":hover"].backgroundColor).toBe(
 				"var(--primary-opacity-50)",
 			);
+			expect(styles.container[":focus-visible"].outline).toBe(
+				"2px solid currentColor",
+			);
+			expect(styles.container[":active"].transform).toBe("translateY(1px)");
 		});
 
 		it("should preserve non-ThemeColor values", () => {


### PR DESCRIPTION
## Summary

- adds typed `:hover`, `:focus`, `:focus-visible`, and `:active` states to `NubeComponentStyle`
- documents the colon-only selector syntax used by `StyleSheet.create`
- keeps nested state parsing covered through `StyleSheet` tests
- bumps `@tiendanube/nube-sdk-types` to `0.92.0`

## Test plan

- [x] `npm test`
- [x] `npm run check`
- [x] `npm run build`

Closes #382


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for styling interactive states such as `:active`, `:focus`, `:focus-visible`, and `:hover`.
  * Enhanced component styles to support nested pseudo-class definitions while preserving theme-aware color handling.
* **Bug Fixes**
  * Improved style processing for focus-visible and active states.
* **Chores**
  * Updated the types package version to 0.94.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->