### PR TITLE
feat(types): add state_level property to store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7042,6 +7042,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7063,6 +7064,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7084,6 +7086,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7105,6 +7108,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7126,6 +7130,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7147,6 +7152,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7168,6 +7174,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7189,6 +7196,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7210,6 +7218,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7231,6 +7240,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7252,6 +7262,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10629,7 +10640,7 @@
       }
     },
     "packages/create-nube-app": {
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
@@ -10767,7 +10778,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.91.0",
+      "version": "0.92.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.91.0",
+	"version": "0.92.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -411,6 +411,15 @@ export type Store = {
 
 	/** Whether products can be added to the cart without redirecting to the cart page. */
 	quick_cart: boolean;
+
+	/**
+	 * Level of detail of the product lists exposed in {@link NubeSDKState.location}.
+	 *
+	 * - `"minimal"`: each product contains only `id` and `name`.
+	 * - `"light"`: each product contains a reduced set of fields.
+	 * - `"full"`: each product contains all available fields.
+	 */
+	state_level: "minimal" | "light" | "full";
 };
 
 type FixedProductListSectionName =


### PR DESCRIPTION
## Summary

Adds the `state_level` property to the `Store` type, describing the level of detail of the product lists exposed in `NubeSDKState.location`:

- `"minimal"`: each product contains only `id` and `name`.
- `"light"`: each product contains a reduced set of fields.
- `"full"`: each product contains all available fields.

Bumps `@tiendanube/nube-sdk-types` to `0.92.0`.

## Changes

- [packages/types/src/domain.ts](packages/types/src/domain.ts): new `state_level: "minimal" | "light" | "full"` field on `Store`, with docs.
- [packages/types/package.json](packages/types/package.json): version `0.91.0` → `0.92.0`.
- `package-lock.json`: refreshed (version bumps + `peer` flags on optional platform binaries).

## Test plan

- [x] Typecheck / build passes on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store data now indicates the level of product details available: minimal, light, or full.

* **Chores**
  * Updated the package version to 0.92.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->