### PR TITLE
feat(types): add types for fullscreen video

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.92.0",
+	"version": "0.93.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -766,6 +766,20 @@ export type NubeComponentVideoBufferHandler = NubeComponentEventHandler<
 	NubeComponentVideoBufferPayload
 >;
 
+/** Payload emitted with the `open` event (video entered fullscreen). No structured data. */
+export type NubeComponentVideoOpenPayload = Record<string, never>;
+/** Payload emitted with the `close` event (video exited fullscreen). No structured data. */
+export type NubeComponentVideoClosePayload = Record<string, never>;
+
+export type NubeComponentVideoOpenHandler = NubeComponentEventHandler<
+	"open",
+	NubeComponentVideoOpenPayload
+>;
+export type NubeComponentVideoCloseHandler = NubeComponentEventHandler<
+	"close",
+	NubeComponentVideoClosePayload
+>;
+
 /* -------------------------------------------------------------------------- */
 /*                      Video source-specific errors                          */
 /* -------------------------------------------------------------------------- */
@@ -857,6 +871,10 @@ export type NubeComponentVideoRootProps = Prettify<
 		onEnded?: NubeComponentVideoEndedHandler;
 		onProgress?: NubeComponentVideoProgressHandler;
 		onBuffer?: NubeComponentVideoBufferHandler;
+		/** Fired when the video enters the fullscreen overlay. */
+		onOpen?: NubeComponentVideoOpenHandler;
+		/** Fired when the fullscreen overlay closes. */
+		onClose?: NubeComponentVideoCloseHandler;
 		children: NubeComponentChildren;
 	}
 >;
@@ -883,6 +901,11 @@ export type NubeComponentVideoPlayerProps = Prettify<
 		poster?: SecurityURL;
 		/** Show the player's default controls. Defaults to `true`. */
 		controls?: boolean;
+		/**
+		 * Aspect ratio as `"width/height"` (e.g. `"16/9"`, `"9/16"`). Defaults to
+		 * `"16/9"`. Ignored in fullscreen, where the video letterboxes to fit the viewport.
+		 */
+		aspectRatio?: string;
 		/**
 		 * Enable the fullscreen "lightbox": an absoluteFill overlay that fills the
 		 * viewport (CSS, not native fullscreen) with a mandatory close button and

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -30,6 +30,7 @@ import type {
  * @property {"after_header"} AFTER_HEADER - After the header.
  * @property {"drawer_left"} DRAWER_LEFT - Left drawer.
  * @property {"drawer_right"} DRAWER_RIGHT - Right drawer.
+ * @property {"fullscreen_content"} FULLSCREEN_CONTENT - Fullscreen overlay; accepts a `Video.Root` component.
  */
 export const COMMON_UI_SLOT = {
 	BEFORE_MAIN_CONTENT: "before_main_content",
@@ -48,6 +49,7 @@ export const COMMON_UI_SLOT = {
 	AFTER_HEADER: "after_header",
 	DRAWER_LEFT: "drawer_left",
 	DRAWER_RIGHT: "drawer_right",
+	FULLSCREEN_CONTENT: "fullscreen_content",
 } as const;
 
 /**


### PR DESCRIPTION
## Description

This PR adds a new slot for `fullscreen_content`. So far only supported component for the slot is `Video.Root`.
It also adds `onOpen` and `onClose` callbacks, and allows setting `aspectRatio` to video (before was always `16/9`, now defaults to that value).

## Novos slots

| Constant | Value | Where |
| --- | --- | --- |
| `FULLSCREEN_CONTENT` | `fullscreen_content` | Covers the entire window |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storefront customization slots around promotion, best-seller, coming-soon, recent, and slider product sections.
  * Added before-and-after slots for the main product section, enabling additional content or components to be placed around these areas.

* **Documentation**
  * Documented the newly available storefront UI slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->