### PR TITLE
feat(types): add home banner section slots to STOREFRONT_UI_SLOT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7042,7 +7042,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7064,7 +7063,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7086,7 +7084,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7108,7 +7105,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7130,7 +7126,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7152,7 +7147,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7174,7 +7168,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7196,7 +7189,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7218,7 +7210,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7240,7 +7231,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7262,7 +7252,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10679,7 +10668,7 @@
     },
     "packages/helper": {
       "name": "@tiendanube/nube-sdk-helper",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
@@ -10778,7 +10767,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.92.0",
+      "version": "0.94.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.93.0",
+	"version": "0.94.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -154,6 +154,18 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_section_products_new"} AFTER_SECTION_PRODUCTS_NEW - After the products new section on the home page.
  * @property {"before_section_products_featured"} BEFORE_SECTION_PRODUCTS_FEATURED - Before the products featured section on the home page.
  * @property {"after_section_products_featured"} AFTER_SECTION_PRODUCTS_FEATURED - After the products featured section on the home page.
+ * @property {"before_section_banner_categories"} BEFORE_SECTION_BANNER_CATEGORIES - Before the categories banner section on the home page.
+ * @property {"after_section_banner_categories"} AFTER_SECTION_BANNER_CATEGORIES - After the categories banner section on the home page.
+ * @property {"before_section_banner_promotional"} BEFORE_SECTION_BANNER_PROMOTIONAL - Before the promotional banner section on the home page.
+ * @property {"after_section_banner_promotional"} AFTER_SECTION_BANNER_PROMOTIONAL - After the promotional banner section on the home page.
+ * @property {"before_section_banner_news"} BEFORE_SECTION_BANNER_NEWS - Before the news banner section on the home page.
+ * @property {"after_section_banner_news"} AFTER_SECTION_BANNER_NEWS - After the news banner section on the home page.
+ * @property {"before_section_banner_featured"} BEFORE_SECTION_BANNER_FEATURED - Before the featured banner section on the home page.
+ * @property {"after_section_banner_featured"} AFTER_SECTION_BANNER_FEATURED - After the featured banner section on the home page.
+ * @property {"before_section_banner_with_text"} BEFORE_SECTION_BANNER_WITH_TEXT - Before the with text banner section on the home page.
+ * @property {"after_section_banner_with_text"} AFTER_SECTION_BANNER_WITH_TEXT - After the with text banner section on the home page.
+ * @property {"before_section_banner_with_image"} BEFORE_SECTION_BANNER_WITH_IMAGE - Before the with image banner section on the home page.
+ * @property {"after_section_banner_with_image"} AFTER_SECTION_BANNER_WITH_IMAGE - After the with image banner section on the home page.
  * @property {"before_product_detail_related_products"} BEFORE_PRODUCT_DETAIL_RELATED_PRODUCTS - Before the related products section on the product detail page.
  * @property {"after_product_detail_related_products"} AFTER_PRODUCT_DETAIL_RELATED_PRODUCTS - After the related products section on the product detail page.
  * @property {"before_product_detail_complementary_products"} BEFORE_PRODUCT_DETAIL_COMPLEMENTARY_PRODUCTS - Before the complementary products section on the product detail page.
@@ -236,6 +248,18 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_SECTION_PRODUCTS_NEW: "after_section_products_new",
 	BEFORE_SECTION_PRODUCTS_FEATURED: "before_section_products_featured",
 	AFTER_SECTION_PRODUCTS_FEATURED: "after_section_products_featured",
+	BEFORE_SECTION_BANNER_CATEGORIES: "before_section_banner_categories",
+	AFTER_SECTION_BANNER_CATEGORIES: "after_section_banner_categories",
+	BEFORE_SECTION_BANNER_PROMOTIONAL: "before_section_banner_promotional",
+	AFTER_SECTION_BANNER_PROMOTIONAL: "after_section_banner_promotional",
+	BEFORE_SECTION_BANNER_NEWS: "before_section_banner_news",
+	AFTER_SECTION_BANNER_NEWS: "after_section_banner_news",
+	BEFORE_SECTION_BANNER_FEATURED: "before_section_banner_featured",
+	AFTER_SECTION_BANNER_FEATURED: "after_section_banner_featured",
+	BEFORE_SECTION_BANNER_WITH_TEXT: "before_section_banner_with_text",
+	AFTER_SECTION_BANNER_WITH_TEXT: "after_section_banner_with_text",
+	BEFORE_SECTION_BANNER_WITH_IMAGE: "before_section_banner_with_image",
+	AFTER_SECTION_BANNER_WITH_IMAGE: "after_section_banner_with_image",
 	BEFORE_PRODUCT_DETAIL_RELATED_PRODUCTS:
 		"before_product_detail_related_products",
 	AFTER_PRODUCT_DETAIL_RELATED_PRODUCTS:

--- a/packages/types/src/slots.ts
+++ b/packages/types/src/slots.ts
@@ -160,12 +160,6 @@ export const CHECKOUT_UI_SLOT = {
  * @property {"after_section_banner_promotional"} AFTER_SECTION_BANNER_PROMOTIONAL - After the promotional banner section on the home page.
  * @property {"before_section_banner_news"} BEFORE_SECTION_BANNER_NEWS - Before the news banner section on the home page.
  * @property {"after_section_banner_news"} AFTER_SECTION_BANNER_NEWS - After the news banner section on the home page.
- * @property {"before_section_banner_featured"} BEFORE_SECTION_BANNER_FEATURED - Before the featured banner section on the home page.
- * @property {"after_section_banner_featured"} AFTER_SECTION_BANNER_FEATURED - After the featured banner section on the home page.
- * @property {"before_section_banner_with_text"} BEFORE_SECTION_BANNER_WITH_TEXT - Before the with text banner section on the home page.
- * @property {"after_section_banner_with_text"} AFTER_SECTION_BANNER_WITH_TEXT - After the with text banner section on the home page.
- * @property {"before_section_banner_with_image"} BEFORE_SECTION_BANNER_WITH_IMAGE - Before the with image banner section on the home page.
- * @property {"after_section_banner_with_image"} AFTER_SECTION_BANNER_WITH_IMAGE - After the with image banner section on the home page.
  * @property {"before_product_detail_related_products"} BEFORE_PRODUCT_DETAIL_RELATED_PRODUCTS - Before the related products section on the product detail page.
  * @property {"after_product_detail_related_products"} AFTER_PRODUCT_DETAIL_RELATED_PRODUCTS - After the related products section on the product detail page.
  * @property {"before_product_detail_complementary_products"} BEFORE_PRODUCT_DETAIL_COMPLEMENTARY_PRODUCTS - Before the complementary products section on the product detail page.
@@ -254,12 +248,6 @@ export const STOREFRONT_UI_SLOT = {
 	AFTER_SECTION_BANNER_PROMOTIONAL: "after_section_banner_promotional",
 	BEFORE_SECTION_BANNER_NEWS: "before_section_banner_news",
 	AFTER_SECTION_BANNER_NEWS: "after_section_banner_news",
-	BEFORE_SECTION_BANNER_FEATURED: "before_section_banner_featured",
-	AFTER_SECTION_BANNER_FEATURED: "after_section_banner_featured",
-	BEFORE_SECTION_BANNER_WITH_TEXT: "before_section_banner_with_text",
-	AFTER_SECTION_BANNER_WITH_TEXT: "after_section_banner_with_text",
-	BEFORE_SECTION_BANNER_WITH_IMAGE: "before_section_banner_with_image",
-	AFTER_SECTION_BANNER_WITH_IMAGE: "after_section_banner_with_image",
 	BEFORE_PRODUCT_DETAIL_RELATED_PRODUCTS:
 		"before_product_detail_related_products",
 	AFTER_PRODUCT_DETAIL_RELATED_PRODUCTS:


### PR DESCRIPTION
## Descrição

Adiciona 6 novos slots (`before` e `after`) para as seções de banner da home em `STOREFRONT_UI_SLOT`, seguindo o padrão já existente das seções da home (`before_section_products_sale`, etc.): `snake_case` e sem o prefixo `home-` do `data-store`.

## Slot → `data-store`

| Slot | `data-store` | Temas |
|---|---|---|
| `before_section_banner_categories` | `home-banner-categories` | 21 |
| `after_section_banner_categories` | `home-banner-categories` | 21 |
| `before_section_banner_promotional` | `home-banner-promotional` | 19 |
| `after_section_banner_promotional` | `home-banner-promotional` | 19 |
| `before_section_banner_news` | `home-banner-news` | 11 |
| `after_section_banner_news` | `home-banner-news` | 11 |

Cada slot tem sua entrada `@property` no JSDoc do `STOREFRONT_UI_SLOT`.

Os slots de `banner_featured`, `banner_with_image` e `banner_with_text` foram removidos do escopo deste PR por terem cobertura nula ou muito baixa entre os temas (`home-banner-with-text` não aparece em nenhum tema; `home-banner-featured` só em toluca; `home-banner-with-image` só em material e zen). Podem ser adicionados quando houver demanda real.

## Notas

- Sem bump de versão em `packages/types/package.json` — os commits recentes de adição de slot só alteram `slots.ts` e o bump vem em commit separado.

## Testes

- `tsc --noEmit` em `packages/types`: OK
- `biome check src/slots.ts`: OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed six storefront banner UI slots for featured, text, and image sections.
  - These slots are no longer available in the storefront UI slot definitions.
- **Chores**
  - Updated the package version from 0.93.0 to 0.94.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->