### PR TITLE
feat(types): add disabled to checkbox props

### DIFF
--- a/packages/doc/docs/components/checkbox.md
+++ b/packages/doc/docs/components/checkbox.md
@@ -95,6 +95,7 @@ checkbox({
 | name     | string                         | Yes      | The name of the checkbox, used to identify it in forms.       |
 | label    | string                         | Yes      | The label text displayed next to the checkbox.                |
 | checked  | boolean                        | Yes      | The current checked state of the checkbox.                    |
+| disabled | boolean                        | No       | Whether the checkbox is disabled.                             |
 | onChange | NubeComponentCheckEventHandler | No       | Function called when the checkbox state changes.              |
 
 ### Property values

--- a/packages/doc/es/docs/components/checkbox.md
+++ b/packages/doc/es/docs/components/checkbox.md
@@ -95,6 +95,7 @@ checkbox({
 | name     | string                         | Yes      | El nombre del checkbox, usado para identificarlo en formularios. |
 | label    | string                         | Yes      | El texto de la etiqueta mostrada junto al checkbox.              |
 | checked  | boolean                        | Yes      | El estado actual marcado del checkbox.                           |
+| disabled | boolean                        | No       | Si el checkbox está deshabilitado.                               |
 | onChange | NubeComponentCheckEventHandler | No       | Función llamada cuando el estado del checkbox cambia.            |
 
 ### Property values

--- a/packages/doc/pt/docs/components/checkbox.md
+++ b/packages/doc/pt/docs/components/checkbox.md
@@ -95,6 +95,7 @@ checkbox({
 | name        | string                         | Sim         | O nome do checkbox, usado para identificá-lo em formulários.  |
 | label       | string                         | Sim         | O texto do rótulo exibido ao lado do checkbox.                |
 | checked     | boolean                        | Sim         | O estado atual marcado do checkbox.                           |
+| disabled    | boolean                        | Não         | Se o checkbox está desabilitado.                              |
 | onChange    | NubeComponentCheckEventHandler | Não         | Função chamada quando o estado do checkbox muda.              |
 
 ### Valores das propriedades

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -525,6 +525,8 @@ export type NubeComponentCheckboxProps = Prettify<
 		name: string;
 		label: string;
 		checked: boolean;
+		/** Prevents interaction and marks the checkbox as disabled. */
+		disabled?: boolean;
 		onChange?: NubeComponentCheckEventHandler;
 		style?: {
 			container?: NubeComponentStyle;

--- a/packages/ui/src/components/checkbox.spec.ts
+++ b/packages/ui/src/components/checkbox.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { checkbox } from "./checkbox";
+import { formCheckbox } from "./form-checkbox";
+
+describe("checkbox", () => {
+	it("forwards disabled to the component node", () => {
+		const node = checkbox({
+			name: "terms",
+			label: "I agree",
+			checked: false,
+			disabled: true,
+		});
+
+		expect(node.type).toBe("check");
+		expect(node.disabled).toBe(true);
+	});
+
+	it("leaves disabled undefined when it is not passed", () => {
+		const node = checkbox({ name: "terms", label: "I agree", checked: false });
+
+		expect(node.disabled).toBeUndefined();
+	});
+
+	it("accepts the same disabled shape as formCheckbox", () => {
+		// formCheckbox is documented as mirroring the public checkbox props, so
+		// the two have to agree on this one. They did not before: checkbox was
+		// the only input component without `disabled`.
+		const plain = checkbox({
+			name: "opt",
+			label: "Optional item",
+			checked: false,
+			disabled: true,
+		});
+		const inForm = formCheckbox({
+			name: "opt",
+			label: "Optional item",
+			checked: false,
+			disabled: true,
+		});
+
+		expect(plain.disabled).toBe(inForm.disabled);
+	});
+
+	it("keeps disabled independent from checked", () => {
+		// A disabled checkbox can be checked or unchecked: quota pickers render
+		// the already selected items as checked and disabled at the same time.
+		const checkedAndDisabled = checkbox({
+			name: "kit-a",
+			label: "Kit A",
+			checked: true,
+			disabled: true,
+		});
+
+		expect(checkedAndDisabled.checked).toBe(true);
+		expect(checkedAndDisabled.disabled).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #429

## The gap

`NubeComponentCheckboxProps` is `{ name, label, checked, onChange?, style? }`.
Its sibling declares `disabled` on line **1502** of the same file:

```ts
export type NubeComponentFormCheckboxProps = Prettify<
	NubeComponentBase & ChildrenProps & {
		name: string;
		label: string;
		checked?: boolean;
		value?: string;
		required?: boolean;
		disabled?: boolean;          // <-- here
		/** Style slots, same shape as `checkbox.style`. */
		style?: { container?; label?; checkbox? };
	}
>;
```

`field`, `numberfield`, `select`, `button`, `formRadio` and `formSelect` expose
it too. `checkbox` was the only input component without it.

The two types are meant to agree. `form-checkbox.ts` describes `formCheckbox` as
mirroring "the public `checkbox` props", and the JSDoc above the style slots says
"same shape as `checkbox.style`". That reads as an omission rather than a
deliberate restriction.

## Why it matters

From the report in #429: a kit picker with selection quotas has to render the
remaining optional items as disabled once the quota is filled. Without the prop
that rule can only live inside the change handler, which refuses the change after
the shopper already clicked it. That is a worse experience than an input that
looks unavailable in the first place.

## What changed

| file | change |
| --- | --- |
| `packages/types/src/components.ts` | `disabled?: boolean` on `NubeComponentCheckboxProps` |
| `packages/ui/src/components/checkbox.spec.ts` | new, 4 cases |
| `packages/doc/docs/components/checkbox.md` | row in the properties table |
| `packages/doc/es/docs/components/checkbox.md` | same, in Spanish |
| `packages/doc/pt/docs/components/checkbox.md` | same, in Portuguese |

The component factory did not need changes: `checkbox.ts` builds
`{ type: "check", ...props }` and spreads without filtering, so the new prop
flows through on its own.

The four test cases are: `disabled` reaches the node, it stays `undefined` when
omitted, it matches what `formCheckbox` produces for the same input, and it is
independent from `checked` (a quota picker renders items checked and disabled at
the same time).

## Verification

```
npm test        241 tests passing, 4 of them new
npm run check   biome clean, no fixes applied
```

## One thing I could not verify

I looked for where `type: "check"` becomes DOM and did not find it in this
repository: `packages/helper/src/lib/render.ts` does not handle that case.

If the renderer that has to write the `disabled` attribute on the `<input>` lives
on the storefront side, then this PR exposes the prop and documents it, but the
half that makes it take effect is yours. I would rather say that than ship a prop
that shows up in autocomplete and does nothing in the store.

Happy to adjust anything: naming, where the row sits in the docs table, or the
scope. If you would rather not take outside PRs on this repo, just say so and
I will close it, no hard feelings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional `disabled` support for Checkbox components, preventing user interaction when enabled.
  - Disabled checkboxes can remain checked.

- **Documentation**
  - Documented the new `disabled` property in English, Spanish, and Portuguese Checkbox documentation.

- **Tests**
  - Added coverage for disabled-state behavior and compatibility with form checkboxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->