### PR TITLE
feat(types): accessibility props on button and box, row, column

### DIFF
--- a/packages/doc/docs/components/box.md
+++ b/packages/doc/docs/components/box.md
@@ -52,6 +52,12 @@ box({
 | justifyContent | FlexContent           | No       | The CSS property [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) |
 | direction      | "row"<br/>"column"    | No       | Layout direction for children (row for horizontal, column for vertical).                             |
 | id             | string                | No       | Optional unique identifier for the component.                                                        |
+| role | string | No | Maps to the `role` attribute of the host element. |
+| ariaLabel | string | No | Accessible name. Maps to `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | No | Marks the element as the current one within a set. Maps to `aria-current`. |
+| ariaHidden | boolean | No | Hides decorative wrappers from assistive tech. Maps to `aria-hidden`. |
+| ariaRoleDescription | string | No | Human readable description of the role, e.g. "Carousel". |
+| tabIndex | number | No | Makes the element focusable. Maps to `tabindex`. |
 
 ### Property values
 

--- a/packages/doc/docs/components/button.md
+++ b/packages/doc/docs/components/button.md
@@ -83,6 +83,8 @@ button({
 | width    | Size                                                   | No       | Width of the button (e.g., "100%", "200px"). |
 | height   | Size                                                   | No       | Height of the button.                        |
 | onClick  | NubeComponentButtonEventHandler                        | No       | Function called when the button is clicked.  |
+| ariaLabel | string | No | Accessible name. Maps to `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | No | Marks the element as the current one within a set. Maps to `aria-current`. |
 
 ### Property values
 

--- a/packages/doc/docs/components/column.md
+++ b/packages/doc/docs/components/column.md
@@ -51,6 +51,12 @@ column({
 | alignContent   | FlexContent           | No       | The CSS property [align-content](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)     |
 | justifyContent | FlexContent           | No       | The CSS property [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) |
 | id             | string                | No       | Optional unique identifier for the component.                                                        |
+| role | string | No | Maps to the `role` attribute of the host element. |
+| ariaLabel | string | No | Accessible name. Maps to `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | No | Marks the element as the current one within a set. Maps to `aria-current`. |
+| ariaHidden | boolean | No | Hides decorative wrappers from assistive tech. Maps to `aria-hidden`. |
+| ariaRoleDescription | string | No | Human readable description of the role, e.g. "Carousel". |
+| tabIndex | number | No | Makes the element focusable. Maps to `tabindex`. |
 
 ### Property values
 

--- a/packages/doc/docs/components/row.md
+++ b/packages/doc/docs/components/row.md
@@ -51,6 +51,12 @@ row({
 | alignContent   | FlexContent           | No       | The CSS property [align-content](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)     |
 | justifyContent | FlexContent           | No       | The CSS property [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) |
 | id             | string                | No       | Optional unique identifier for the component.                                                        |
+| role | string | No | Maps to the `role` attribute of the host element. |
+| ariaLabel | string | No | Accessible name. Maps to `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | No | Marks the element as the current one within a set. Maps to `aria-current`. |
+| ariaHidden | boolean | No | Hides decorative wrappers from assistive tech. Maps to `aria-hidden`. |
+| ariaRoleDescription | string | No | Human readable description of the role, e.g. "Carousel". |
+| tabIndex | number | No | Makes the element focusable. Maps to `tabindex`. |
 
 ### Property values
 

--- a/packages/doc/es/docs/components/box.md
+++ b/packages/doc/es/docs/components/box.md
@@ -52,6 +52,12 @@ box({
 | alignContent   | FlexContent                    | No          | The CSS property [align-content](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)     |
 | justifyContent | FlexContent                    | No          | The CSS property [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) |
 | id             | string                         | No          | Optional unique identifier for the component.                                                        |
+| role | string | No | Se mapea al atributo `role` del elemento anfitrión. |
+| ariaLabel | string | No | Nombre accesible. Se mapea a `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | No | Marca el elemento como el actual dentro de un conjunto. Se mapea a `aria-current`. |
+| ariaHidden | boolean | No | Oculta contenedores decorativos a las tecnologías de asistencia. Se mapea a `aria-hidden`. |
+| ariaRoleDescription | string | No | Descripción legible del rol, por ejemplo "Carrusel". |
+| tabIndex | number | No | Hace que el elemento pueda recibir foco. Se mapea a `tabindex`. |
 
 ### Valores de propiedad
 

--- a/packages/doc/es/docs/components/button.md
+++ b/packages/doc/es/docs/components/button.md
@@ -83,6 +83,8 @@ button({
 | width     | Size                                                | No        | Ancho del botón (ej: "100%", "200px").           |
 | height    | Size                                                | No        | Altura del botón.                                |
 | onClick   | NubeComponentButtonEventHandler                     | No        | Función llamada cuando se hace clic en el botón. |
+| ariaLabel | string | No | Nombre accesible. Se mapea a `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | No | Marca el elemento como el actual dentro de un conjunto. Se mapea a `aria-current`. |
 
 ### Valores de las propiedades
 

--- a/packages/doc/es/docs/components/column.md
+++ b/packages/doc/es/docs/components/column.md
@@ -51,6 +51,12 @@ column({
 | alignContent   | FlexContent           | No       | La propiedad CSS [align-content](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)   |
 | justifyContent | FlexContent           | No       | La propiedad CSS [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) |
 | id             | string                | No       | Identificador único opcional para el componente.                                                     |
+| role | string | No | Se mapea al atributo `role` del elemento anfitrión. |
+| ariaLabel | string | No | Nombre accesible. Se mapea a `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | No | Marca el elemento como el actual dentro de un conjunto. Se mapea a `aria-current`. |
+| ariaHidden | boolean | No | Oculta contenedores decorativos a las tecnologías de asistencia. Se mapea a `aria-hidden`. |
+| ariaRoleDescription | string | No | Descripción legible del rol, por ejemplo "Carrusel". |
+| tabIndex | number | No | Hace que el elemento pueda recibir foco. Se mapea a `tabindex`. |
 
 ### Property values
 

--- a/packages/doc/es/docs/components/row.md
+++ b/packages/doc/es/docs/components/row.md
@@ -44,6 +44,12 @@ row({
 | width    | string                       | No       | El ancho de la fila.                                          |
 | height   | string                       | No       | La altura de la fila.                                         |
 | align    | "start" \| "center" \| "end" | No       | La alineación horizontal de los elementos hijos.              |
+| role | string | No | Se mapea al atributo `role` del elemento anfitrión. |
+| ariaLabel | string | No | Nombre accesible. Se mapea a `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | No | Marca el elemento como el actual dentro de un conjunto. Se mapea a `aria-current`. |
+| ariaHidden | boolean | No | Oculta contenedores decorativos a las tecnologías de asistencia. Se mapea a `aria-hidden`. |
+| ariaRoleDescription | string | No | Descripción legible del rol, por ejemplo "Carrusel". |
+| tabIndex | number | No | Hace que el elemento pueda recibir foco. Se mapea a `tabindex`. |
 
 ## Additional Properties
 

--- a/packages/doc/pt/docs/components/box.md
+++ b/packages/doc/pt/docs/components/box.md
@@ -53,6 +53,12 @@ box({
 | alignContent   | FlexContent                    | Não         | The CSS property [align-content](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)     |
 | justifyContent | FlexContent                    | Não         | The CSS property [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) |
 | id             | string                         | Não         | Optional unique identifier for the component.                                                        |
+| role | string | Não | Mapeia para o atributo `role` do elemento hospedeiro. |
+| ariaLabel | string | Não | Nome acessível. Mapeia para `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | Não | Marca o elemento como o atual dentro de um conjunto. Mapeia para `aria-current`. |
+| ariaHidden | boolean | Não | Esconde contêineres decorativos das tecnologias assistivas. Mapeia para `aria-hidden`. |
+| ariaRoleDescription | string | Não | Descrição legível do papel, por exemplo "Carrossel". |
+| tabIndex | number | Não | Torna o elemento focável. Mapeia para `tabindex`. |
 
 ### Valores das propriedades
 

--- a/packages/doc/pt/docs/components/button.md
+++ b/packages/doc/pt/docs/components/button.md
@@ -83,6 +83,8 @@ button({
 | width       | Size                                                | Não         | Largura do botão (ex: "100%", "200px").    |
 | height      | Size                                                | Não         | Altura do botão.                           |
 | onClick     | NubeComponentButtonEventHandler                     | Não         | Função chamada quando o botão é clicado.   |
+| ariaLabel | string | Não | Nome acessível. Mapeia para `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | Não | Marca o elemento como o atual dentro de um conjunto. Mapeia para `aria-current`. |
 
 ### Valores das propriedades
 

--- a/packages/doc/pt/docs/components/column.md
+++ b/packages/doc/pt/docs/components/column.md
@@ -52,6 +52,12 @@ column({
 | alignContent   | FlexContent                    | Não         | The CSS property [align-content](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)     |
 | justifyContent | FlexContent                    | Não         | The CSS property [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) |
 | id             | string                         | Não         | Optional unique identifier for the component.                                                        |
+| role | string | Não | Mapeia para o atributo `role` do elemento hospedeiro. |
+| ariaLabel | string | Não | Nome acessível. Mapeia para `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | Não | Marca o elemento como o atual dentro de um conjunto. Mapeia para `aria-current`. |
+| ariaHidden | boolean | Não | Esconde contêineres decorativos das tecnologias assistivas. Mapeia para `aria-hidden`. |
+| ariaRoleDescription | string | Não | Descrição legível do papel, por exemplo "Carrossel". |
+| tabIndex | number | Não | Torna o elemento focável. Mapeia para `tabindex`. |
 
 ### Valores das propriedades
 

--- a/packages/doc/pt/docs/components/row.md
+++ b/packages/doc/pt/docs/components/row.md
@@ -52,6 +52,12 @@ row({
 | alignContent   | FlexContent                    | Não         | The CSS property [align-content](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)     |
 | justifyContent | FlexContent                    | Não         | The CSS property [justify-content](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) |
 | id             | string                         | Não         | Optional unique identifier for the component.                                                        |
+| role | string | Não | Mapeia para o atributo `role` do elemento hospedeiro. |
+| ariaLabel | string | Não | Nome acessível. Mapeia para `aria-label`. |
+| ariaCurrent | boolean<br/>"page"<br/>"step"<br/>"location"<br/>"date"<br/>"time" | Não | Marca o elemento como o atual dentro de um conjunto. Mapeia para `aria-current`. |
+| ariaHidden | boolean | Não | Esconde contêineres decorativos das tecnologias assistivas. Mapeia para `aria-hidden`. |
+| ariaRoleDescription | string | Não | Descrição legível do papel, por exemplo "Carrossel". |
+| tabIndex | number | Não | Torna o elemento focável. Mapeia para `tabindex`. |
 
 ### Valores das propriedades
 

--- a/packages/types/src/components.ts
+++ b/packages/types/src/components.ts
@@ -131,9 +131,37 @@ export type NubeComponentStyle = Partial<EnhancedCSSProperties>;
 /**
  * Represents the properties available for a `box` component.
  */
+/**
+ * Accessibility properties shared by the components that can carry them.
+ *
+ * Names follow the camelCase convention already used by `button` and
+ * `formSubmitter` (`ariaLabel`), not the quoted kebab-case of
+ * {@link ProgressAriaProps}. Both spellings exist in this file for historical
+ * reasons; new props use the camelCase one.
+ */
+export type NubeAriaProps = Partial<{
+	/** Maps to the `role` attribute on the host element. */
+	role: string;
+	/** Accessible name. Maps to `aria-label`. */
+	ariaLabel: string;
+	/**
+	 * Marks the element as the current one within a set. Maps to
+	 * `aria-current`. Accepts the full set of values, not just a boolean:
+	 * a carousel bullet uses `"true"`, a breadcrumb uses `"page"`.
+	 */
+	ariaCurrent: boolean | "page" | "step" | "location" | "date" | "time";
+	/** Hides decorative wrappers from assistive tech. Maps to `aria-hidden`. */
+	ariaHidden: boolean;
+	/** Human readable description of the role, e.g. "Carousel". */
+	ariaRoleDescription: string;
+	/** Makes the element focusable. Maps to `tabindex`. */
+	tabIndex: number;
+}>;
+
 export type NubeComponentBoxProps = Prettify<
 	NubeComponentProps &
 		ChildrenProps &
+		NubeAriaProps &
 		Partial<{
 			width: Size;
 			height: Size;
@@ -459,6 +487,11 @@ export type NubeComponentButtonProps = Prettify<
 			style?: NubeComponentStyle;
 			onClick: NubeComponentButtonEventHandler;
 			ariaLabel: string;
+			/**
+			 * Marks the button as the current one within a set. Maps to
+			 * `aria-current`. Carousel pagination bullets use `"true"`.
+			 */
+			ariaCurrent: boolean | "page" | "step" | "location" | "date" | "time";
 		}>
 >;
 

--- a/packages/ui/src/components/aria.spec.ts
+++ b/packages/ui/src/components/aria.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { box } from "./box";
+import { button } from "./button";
+import { column } from "./column";
+import { row } from "./row";
+
+describe("accessibility props", () => {
+	it("box carries role, aria and tabIndex", () => {
+		const node = box({
+			role: "region",
+			ariaLabel: "Customer reviews",
+			ariaRoleDescription: "Carousel",
+			tabIndex: 0,
+		});
+
+		expect(node.type).toBe("box");
+		expect(node.role).toBe("region");
+		expect(node.ariaLabel).toBe("Customer reviews");
+		expect(node.ariaRoleDescription).toBe("Carousel");
+		expect(node.tabIndex).toBe(0);
+	});
+
+	it("row and column inherit them from box", () => {
+		// Row and Column are Omit<NubeComponentBoxProps, "direction">, so they
+		// get whatever Box gets. This test is here to catch the day someone
+		// stops deriving them from Box.
+		const r = row({ role: "group", ariaLabel: "Slide 1 of 4" });
+		const c = column({ ariaHidden: true });
+
+		expect(r.role).toBe("group");
+		expect(r.ariaLabel).toBe("Slide 1 of 4");
+		expect(c.ariaHidden).toBe(true);
+	});
+
+	it("button carries ariaCurrent", () => {
+		const node = button({ children: "1", ariaCurrent: true });
+
+		expect(node.ariaCurrent).toBe(true);
+	});
+
+	it("ariaCurrent accepts the non boolean values of the attribute", () => {
+		// aria-current is not a boolean in the spec: a breadcrumb uses "page",
+		// a wizard uses "step". Restricting it to boolean would close the door
+		// on those without any reason.
+		expect(button({ children: "Home", ariaCurrent: "page" }).ariaCurrent).toBe(
+			"page",
+		);
+		expect(box({ ariaCurrent: "step" }).ariaCurrent).toBe("step");
+	});
+
+	it("leaves every accessibility prop undefined when not passed", () => {
+		const node = box({});
+
+		expect(node.role).toBeUndefined();
+		expect(node.ariaLabel).toBeUndefined();
+		expect(node.ariaCurrent).toBeUndefined();
+		expect(node.ariaHidden).toBeUndefined();
+		expect(node.tabIndex).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Two issues asking for the same thing from opposite ends: #417 wants
`aria-current` on `button` for carousel pagination bullets, #416 wants role,
ARIA attributes and `tabIndex` on the layout containers so a reviews carousel
can follow the WAI-ARIA pattern.

Solved with one shared type instead of two separate patches.

## The naming decision

This file already has two ARIA conventions living side by side. `button` (line
461) and `formSubmitter` (1595, 1624) use camelCase:

    ariaLabel: string;

while `progress` has its own type in quoted kebab-case (632-637):

    export type ProgressAriaProps = {
        "aria-valuemax"?: number;
        "aria-label"?: string;
        ...
    };

So `aria-label` was already spelled two different ways. Adding `ariaCurrent`
without deciding would have made it three.

`NubeAriaProps` follows camelCase, because that is what this family of
components already uses and switching now would break anyone passing
`ariaLabel` today. The JSDoc says so, and points at `ProgressAriaProps`, so the
next person does not have to rediscover it.

## Why box covers three components

`NubeComponentRowProps` and `NubeComponentColumnProps` are
`Omit<NubeComponentBoxProps, "direction">`, so adding the type to Box gives it
to Row and Column for free. There is a test that fails the day someone stops
deriving them from Box.

## ariaCurrent is not a boolean

The attribute takes `page`, `step`, `location`, `date` and `time` besides
`true`. The carousel bullets in #417 only need `true`, but restricting the type
to boolean would close the door on breadcrumbs and wizards for no reason.

## What is deliberately not here

#416 also asks for `onKeyDown` on the containers. A keyboard handler needs event
plumbing that crosses the sandbox boundary, and that half does not live in this
repository, so it is not in this change. #416 stays open for it.

Also documents `ariaLabel` on the `button` page, which existed in the type since
before but was missing from the properties table. #417 mentions this at the end.

## Verified

    npm test        128 tests in the ui package, 5 of them new
    npm run check   biome clean

Docs updated across en, es and pt for button, box, row and column: twelve files.
Worth noting for whoever touches them next: the Spanish translation is
inconsistent about the heading, `button` and `box` use "## Propiedades" while
`row` uses "## Properties".

---

Closes #417. Addresses the type side of #416, which stays open for the `onKeyDown` part.

Same caveat as #444: I could not find where these component types become DOM in this repository, so if the renderer that writes the attributes lives on the storefront side, this exposes and documents the props but the half that makes them reach the page is yours. Happy to close it if you would rather not take outside PRs here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility properties—including ARIA labels, roles, visibility states, descriptions, current states, and keyboard focus—to Box, Row, Column, and Button components.
  * Added support for string-based `ariaCurrent` values on Button.
* **Documentation**
  * Updated English, Spanish, and Portuguese component documentation with the new accessibility options.
* **Tests**
  * Added coverage verifying accessibility properties, inheritance, defaults, and supported `ariaCurrent` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->