### PR TITLE
chore(types): bump version to 0.96.0 for @tiendanube/nube-sdk-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10767,7 +10767,7 @@
     },
     "packages/types": {
       "name": "@tiendanube/nube-sdk-types",
-      "version": "0.95.0",
+      "version": "0.96.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tiendanube/nube-sdk-types",
-	"version": "0.95.0",
+	"version": "0.96.0",
 	"description": "Type definition of NubeSDK",
 	"type": "module",
 	"main": "./src/index.ts",


### PR DESCRIPTION
This pull request updates the version number of the `@tiendanube/nube-sdk-types` package to `0.96.0` to reflect recent changes.

- Versioning:
  * [`packages/types/package.json`](diffhunk://#diff-d20e06952213067104fa5b4a1976cbc97cd55806ac11d137d92c905d63c15054L3-R3): Bumped the package version from `0.95.0` to `0.96.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK types package to version 0.96.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->